### PR TITLE
Remove deprecated isarray usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var vfile = require('vfile');
 var trough = require('trough');
 var string = require('x-is-string');
 var func = require('x-is-function');
-var array = require('isarray');
 var plain = require('is-plain-obj');
 
 /* Expose a frozen processor. */
@@ -220,7 +219,7 @@ function unified() {
 
       if (plugins === null || plugins === undefined) {
         /* Empty */
-      } else if (array(plugins)) {
+      } else if (Array.isArray(plugins)) {
         length = plugins.length;
         index = -1;
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "extend": "^3.0.0",
     "has": "^1.0.1",
     "is-plain-obj": "^1.1.0",
-    "isarray": "^2.0.1",
     "trough": "^1.0.0",
     "vfile": "^2.0.0",
     "x-is-function": "^1.0.4",


### PR DESCRIPTION
This package is deprecated shows warning on `npm install`:

```
isarray@2.0.1: Just use Array.isArray directly
```

So I did that.