### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-- lts/boron
+- 6
+- 8
+- 10
 - node
 after_script: bash <(curl -s https://codecov.io/bash)
 deploy:


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/unifiedjs/unified/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->

Current LTS branches are 6, 8 and 10. So we should test them all to make sure that nothing is breaking there (due to dependencies).
