### PR TITLE
docs(README.md): Add link to website to logo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# ![unified][logo]
+# [![unified][logo]](https://unified.js.org/)
 
 [![Travis][build-badge]][build]
 [![Coverage][coverage-badge]][coverage]


### PR DESCRIPTION
Right now, the logo just goes to the SVG. I figure clicking it might as well go somewhere useful - like the unified website.
