### PR TITLE
Add Spectrum info on how to get help

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,11 @@ It’s used to check code for [Storybook][], [debugger.html][] ([Mozilla][]),
 and [opensource.guide][] ([GitHub][]).
 
 *   To read about what we’re up to, follow us on [Medium][] and [Twitter][]
-*   For a less technical and more practical introduction to unified, visit [`unified.js.org`][site] and try its introductory [Guides][]
+*   For a less technical and more practical introduction to unified, visit
+    [`unified.js.org`][site] and try its introductory [Guides][]
 *   Got questions?  Get help on [our Spectrum community][spectrum]!
-*   To help us out, see [`contributing.md`][contributing], or become a backer or sponsor on [Open Collective][collective]
+*   To help us out, see [`contributing.md`][contributing], or become a backer
+    or sponsor on [Open Collective][collective]
 
 * * *
 

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ and [opensource.guide][] ([GitHub][]).
 *   To read about what we’re up to, follow us on [Medium][] and [Twitter][]
 *   For a less technical and more practical introduction to unified, visit
     [`unified.js.org`][site] and try its introductory [Guides][]
+*   Got questions? Get help on [our Spectrum community](https://spectrum.chat/unified?tab=posts)!
 *   To help us out, see [`contributing.md`][contributing], or become a backer
     or sponsor on [Open Collective][collective]
 

--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,9 @@ It’s used to check code for [Storybook][], [debugger.html][] ([Mozilla][]),
 and [opensource.guide][] ([GitHub][]).
 
 *   To read about what we’re up to, follow us on [Medium][] and [Twitter][]
-*   For a less technical and more practical introduction to unified, visit
-    [`unified.js.org`][site] and try its introductory [Guides][]
+*   For a less technical and more practical introduction to unified, visit [`unified.js.org`][site] and try its introductory [Guides][]
 *   Got questions? Get help on [our Spectrum community](https://spectrum.chat/unified?tab=posts)!
-*   To help us out, see [`contributing.md`][contributing], or become a backer
-    or sponsor on [Open Collective][collective]
+*   To help us out, see [`contributing.md`][contributing], or become a backer or sponsor on [Open Collective][collective]
 
 * * *
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ and [opensource.guide][] ([GitHub][]).
 
 *   To read about what we’re up to, follow us on [Medium][] and [Twitter][]
 *   For a less technical and more practical introduction to unified, visit [`unified.js.org`][site] and try its introductory [Guides][]
-*   Got questions? Get help on [our Spectrum community](https://spectrum.chat/unified?tab=posts)!
+*   Got questions?  Get help on [our Spectrum community][spectrum]!
 *   To help us out, see [`contributing.md`][contributing], or become a backer or sponsor on [Open Collective][collective]
 
 * * *
@@ -1084,6 +1084,8 @@ work on [`ware`][ware], which was a huge initial inspiration.
 [collective]: https://opencollective.com/unified
 
 [guides]: https://unified.js.org/#guides
+
+[spectrum]: http://spectrum.chat/unified
 
 [rehype]: https://github.com/rehypejs/rehype
 


### PR DESCRIPTION
The introductory README lacks information on how to get help when using Unified. This pull requests  orientate users on how to get their questions answered or help others by pointing them to our already existing **[Unified community on Spectrum](https://spectrum.chat/unified)**.

The community itself is already in the README but I wasn't aware it was a thing – it might be the case for others too. Hopefully this will increase visibility!