### PR TITLE
use unist, vfile types instead of definitelytyped

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "vfile": "^4.0.0"
   },
   "devDependencies": {
-    "@types/unist": "^2.0.0",
-    "@types/vfile": "^3.0.0",
     "browserify": "^16.0.0",
     "dtslint": "^0.8.0",
     "nyc": "^14.0.0",


### PR DESCRIPTION
`unist` and `vfile` both already ship with types so removing the `@types/*` `DefinitelyTyped` definitions doesn't cause any issues. Ran `yarn test` and no complaints there.

<!--
Read the [contributing guidelines](https://github.com/unifiedjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/unifiedjs/.github/blob/master/support.md
https://github.com/unifiedjs/.github/blob/master/contributing.md
-->
