### PR TITLE
allow plugins to declare an interface for their settings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,7 @@ import {VFile, VFileContents, VFileOptions} from 'vfile'
 import vfile = require('vfile')
 
 declare namespace unified {
-  interface Processor {
+  interface Processor<T = Settings> {
     /**
      * @returns New unfrozen processor which is configured to function the same as its ancestor. But when the descendant processor is configured in the future it does not affect the ancestral processor.
      */
@@ -18,7 +18,7 @@ declare namespace unified {
      * @param options Configuration for plugin]
      * @returns The processor on which use is invoked
      */
-    use(plugin: Plugin, options?: unknown): Processor
+    use<T = Settings>(plugin: Plugin<T>, options?: T): Processor
     /**
      * @param preset `Object` with an optional plugins (set to list), and/or an optional settings object
      */
@@ -26,11 +26,11 @@ declare namespace unified {
     /**
      * @param pluginTuple pairs, plugin and options in an array
      */
-    use(pluginTuple: PluginTuple): Processor
+    use<T = Settings>(pluginTuple: PluginTuple<T>): Processor
     /**
      * @param list List of plugins, presets, and pairs
      */
-    use(list: PluggableList): Processor
+    use<T = Settings>(list: PluggableList<T>): Processor
 
     /**
      * Parse text to a syntax tree.
@@ -145,7 +145,7 @@ declare namespace unified {
     freeze(): Processor
   }
 
-  type Plugin = Attacher
+  type Plugin<T = Settings> = Attacher<T>
   type Settings = {
     [key: string]: unknown
   }
@@ -157,9 +157,9 @@ declare namespace unified {
     plugins?: PluggableList
     settings?: Settings
   }
-  type PluginTuple = [Plugin, Settings]
-  type Pluggable = Plugin | Preset | PluginTuple
-  type PluggableList = Pluggable[]
+  type PluginTuple<T = Settings> = [Plugin<T>, T]
+  type Pluggable<T = Settings> = Plugin<T> | Preset | PluginTuple<T>
+  type PluggableList<T = Settings> = Array<Pluggable<T>>
 
   /**
    * An attacher is the thing passed to `use`.
@@ -171,8 +171,8 @@ declare namespace unified {
    * @param options Configuration
    * @returns Optional.
    */
-  interface Attacher {
-    (this: Processor, options?: unknown): Transformer | void
+  interface Attacher<T = Settings> {
+    (this: Processor, options?: T): Transformer | void
   }
 
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,7 +30,7 @@ declare namespace unified {
     /**
      * @param list List of plugins, presets, and pairs
      */
-    use<T = Settings>(list: PluggableList<T>): Processor
+    use(list: PluggableList): Processor
 
     /**
      * Parse text to a syntax tree.
@@ -159,7 +159,7 @@ declare namespace unified {
   }
   type PluginTuple<T = Settings> = [Plugin<T>, T]
   type Pluggable<T = Settings> = Plugin<T> | Preset | PluginTuple<T>
-  type PluggableList<T = Settings> = Array<Pluggable<T>>
+  type PluggableList = Array<Pluggable<any>>
 
   /**
    * An attacher is the thing passed to `use`.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,7 @@ import {VFile, VFileContents, VFileOptions} from 'vfile'
 import vfile = require('vfile')
 
 declare namespace unified {
-  interface Processor<T = Settings> {
+  interface Processor {
     /**
      * @returns New unfrozen processor which is configured to function the same as its ancestor. But when the descendant processor is configured in the future it does not affect the ancestral processor.
      */
@@ -15,18 +15,33 @@ declare namespace unified {
      * Configure the processor to use a plugin and optionally configure that plugin with options.
      *
      * @param plugin unified plugin
-     * @param options Configuration for plugin]
+     * @param options Configuration for plugin
+     * @param extraOptions Additional configuration for plugin
      * @returns The processor on which use is invoked
      */
-    use<T = Settings>(plugin: Plugin<T>, options?: T): Processor
+    use<T = Settings, S = undefined>(
+      plugin: Plugin<T, S>,
+      options?: T,
+      extraOptions?: S
+    ): Processor
+
     /**
      * @param preset `Object` with an optional plugins (set to list), and/or an optional settings object
      */
     use(preset: Preset): Processor
+
     /**
      * @param pluginTuple pairs, plugin and options in an array
      */
     use<T = Settings>(pluginTuple: PluginTuple<T>): Processor
+
+    /**
+     * @param pluginTriple plugin, options, and extraOptions in an array
+     */
+    use<T = Settings, S = undefined>(
+      pluginTriple: PluginTriple<T, S>
+    ): Processor
+
     /**
      * @param list List of plugins, presets, and pairs
      */
@@ -145,7 +160,7 @@ declare namespace unified {
     freeze(): Processor
   }
 
-  type Plugin<T = Settings> = Attacher<T>
+  type Plugin<T = Settings, S = undefined> = Attacher<T, S>
   type Settings = {
     [key: string]: unknown
   }
@@ -158,8 +173,13 @@ declare namespace unified {
     settings?: Settings
   }
   type PluginTuple<T = Settings> = [Plugin<T>, T]
-  type Pluggable<T = Settings> = Plugin<T> | Preset | PluginTuple<T>
-  type PluggableList = Array<Pluggable<any>>
+  type PluginTriple<T = Settings, S = undefined> = [Plugin<T, S>, T, S]
+  type Pluggable<T = Settings, S = undefined> =
+    | Plugin<T>
+    | Preset
+    | PluginTuple<T>
+    | PluginTriple<T, S>
+  type PluggableList = Array<Pluggable<any, any>>
 
   /**
    * An attacher is the thing passed to `use`.
@@ -169,10 +189,11 @@ declare namespace unified {
    *
    * @this Processor context object is set to the invoked on processor.
    * @param options Configuration
+   * @param extraOptions Secondary configuration
    * @returns Optional.
    */
-  interface Attacher<T = Settings> {
-    (this: Processor, options?: T): Transformer | void
+  interface Attacher<T = Settings, S = undefined> {
+    (this: Processor, options?: T, extraOptions?: S): Transformer | void
   }
 
   /**

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -9,6 +9,7 @@
     "semicolon": false,
     "unified-signatures": false,
     "whitespace": false,
-    "interface-over-type-literal": false
+    "interface-over-type-literal": false,
+    "no-unnecessary-generics": false
   }
 }

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -33,7 +33,12 @@ interface ExamplePluginSettings {
 const typedPlugin: Plugin<ExamplePluginSettings> = function() {}
 const typedSetting = {example: 'example'}
 
-const implicitlyTypedPlugin = (settings?: ExamplePluginSettings) => {}  
+const implicitlyTypedPlugin = (settings?: ExamplePluginSettings) => {}
+
+const pluginWithTwoSettings = (
+  processor?: Processor,
+  settings?: ExamplePluginSettings
+) => {}
 
 processor.use(plugin)
 processor.use(plugin).use(plugin)
@@ -55,19 +60,57 @@ processor.use(implicitlyTypedPlugin)
 processor.use(implicitlyTypedPlugin).use(implicitlyTypedPlugin)
 processor.use(implicitlyTypedPlugin, typedSetting)
 processor.use([implicitlyTypedPlugin, typedSetting])
-processor.use([[implicitlyTypedPlugin, typedSetting], [implicitlyTypedPlugin, typedSetting]])
-processor.use([[implicitlyTypedPlugin, settings], [implicitlyTypedPlugin, typedSetting]])
+processor.use([
+  [implicitlyTypedPlugin, typedSetting],
+  [implicitlyTypedPlugin, typedSetting]
+])
+processor.use([[plugin, settings], [implicitlyTypedPlugin, typedSetting]])
 processor.use([implicitlyTypedPlugin])
+
+// NOTE: settings overrides the generic undefined
+// settings value will be unused but TypeScript will not warn
+processor.use(implicitlyTypedPlugin, typedSetting, settings)
+processor.use([implicitlyTypedPlugin, typedSetting, settings])
+
+processor.use(pluginWithTwoSettings)
+processor.use(pluginWithTwoSettings).use(pluginWithTwoSettings)
+processor.use(pluginWithTwoSettings, processor, typedSetting)
+processor.use(pluginWithTwoSettings, processor)
+processor.use([pluginWithTwoSettings, processor, typedSetting])
+processor.use([pluginWithTwoSettings, processor])
+processor.use([
+  [pluginWithTwoSettings, processor, typedSetting],
+  [pluginWithTwoSettings, processor, typedSetting]
+])
+processor.use([
+  [plugin, settings],
+  [pluginWithTwoSettings, processor, typedSetting]
+])
+processor.use([pluginWithTwoSettings])
 
 // $ExpectError
 processor.use(typedPlugin, settings)
 // $ExpectError
 processor.use([typedPlugin, settings])
+// $ExpectError
+processor.use(typedPlugin, typedSetting, settings)
+// $ExpectError
+processor.use([typedPlugin, typedSetting, settings])
 
 // $ExpectError
 processor.use(implicitlyTypedPlugin, settings)
 // $ExpectError
 processor.use([implicitlyTypedPlugin, settings])
+
+// $ExpectError
+processor.use(pluginWithTwoSettings, typedSetting)
+// $ExpectError
+processor.use(pluginWithTwoSettings, typedSetting)
+
+// $ExpectError
+processor.use(pluginWithTwoSettings, processor, settings)
+// $ExpectError
+processor.use([pluginWithTwoSettings, processor, settings])
 
 // $ExpectError
 processor.use(false)

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -27,19 +27,40 @@ const settings = {
   random: 'option'
 }
 
+interface ExamplePluginSettings {
+  example: string
+}
+const typedPlugin: Plugin<ExamplePluginSettings> = function() {}
+const typedSetting = {example: 'example'}
+
 processor.use(plugin)
 processor.use(plugin).use(plugin)
+processor.use(plugin, settings)
+processor.use([plugin, plugin])
+processor.use([plugin])
+processor.use([plugin, settings])
+processor.use([[plugin, settings], [plugin, settings]])
+
+processor.use(typedPlugin)
+processor.use(typedPlugin).use(typedPlugin)
+processor.use(typedPlugin, typedSetting)
+processor.use([typedPlugin, typedSetting])
+processor.use([[typedPlugin, typedSetting], [typedPlugin, typedSetting]])
+processor.use([typedPlugin])
+
+// $ExpectError
+processor.use(typedPlugin, settings)
+// $ExpectError
+processor.use([typedPlugin, settings])
+// $ExpectError
+processor.use([[typedPlugin, settings], [typedPlugin, settings]])
+
 // $ExpectError
 processor.use(false)
 // $ExpectError
 processor.use(true)
 // $ExpectError
 processor.use('alfred')
-processor.use(plugin, settings)
-processor.use([plugin, plugin])
-processor.use([plugin])
-processor.use([plugin, settings])
-processor.use([[plugin, settings], [plugin, settings]])
 // $ExpectError
 processor.use([false])
 // $ExpectError
@@ -54,6 +75,7 @@ processor.use({
   // $ExpectError
   plugins: {foo: true}
 })
+
 processor.use({})
 processor.use({
   plugins: []

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -33,6 +33,8 @@ interface ExamplePluginSettings {
 const typedPlugin: Plugin<ExamplePluginSettings> = function() {}
 const typedSetting = {example: 'example'}
 
+const implicitlyTypedPlugin = (settings?: ExamplePluginSettings) => {}  
+
 processor.use(plugin)
 processor.use(plugin).use(plugin)
 processor.use(plugin, settings)
@@ -49,10 +51,23 @@ processor.use([[typedPlugin, typedSetting], [typedPlugin, typedSetting]])
 processor.use([[plugin, settings], [typedPlugin, typedSetting]])
 processor.use([typedPlugin])
 
+processor.use(implicitlyTypedPlugin)
+processor.use(implicitlyTypedPlugin).use(implicitlyTypedPlugin)
+processor.use(implicitlyTypedPlugin, typedSetting)
+processor.use([implicitlyTypedPlugin, typedSetting])
+processor.use([[implicitlyTypedPlugin, typedSetting], [implicitlyTypedPlugin, typedSetting]])
+processor.use([[implicitlyTypedPlugin, settings], [implicitlyTypedPlugin, typedSetting]])
+processor.use([implicitlyTypedPlugin])
+
 // $ExpectError
 processor.use(typedPlugin, settings)
 // $ExpectError
 processor.use([typedPlugin, settings])
+
+// $ExpectError
+processor.use(implicitlyTypedPlugin, settings)
+// $ExpectError
+processor.use([implicitlyTypedPlugin, settings])
 
 // $ExpectError
 processor.use(false)

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -46,14 +46,13 @@ processor.use(typedPlugin).use(typedPlugin)
 processor.use(typedPlugin, typedSetting)
 processor.use([typedPlugin, typedSetting])
 processor.use([[typedPlugin, typedSetting], [typedPlugin, typedSetting]])
+processor.use([[plugin, settings], [typedPlugin, typedSetting]])
 processor.use([typedPlugin])
 
 // $ExpectError
 processor.use(typedPlugin, settings)
 // $ExpectError
 processor.use([typedPlugin, settings])
-// $ExpectError
-processor.use([[typedPlugin, settings], [typedPlugin, settings]])
 
 // $ExpectError
 processor.use(false)


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/unifiedjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/unifiedjs/.github/blob/master/support.md
https://github.com/unifiedjs/.github/blob/master/contributing.md
-->

An initial implementation for https://github.com/remarkjs/remark/pull/383#discussion_r299623495

> Unified types would highly benefit from a generic here. As written, options passed along with the use() call is a place where all type safety is lost.

This makes plugins generic, defaulting to unified's `Settings` type.
Plugins that do not specify a settings interface should *not* be unaffected.