### PR TITLE
Transformers take VFile instead of VFileCompatible

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -310,7 +310,7 @@ declare namespace unified {
   interface Transformer {
     (
       node: Node,
-      file: VFileCompatible,
+      file: VFile,
       next?: (error: Error | null, tree: Node, file: VFile) => {}
     ): Error | Node | Promise<Node>
   }

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -35,6 +35,9 @@ const typedSetting = {example: 'example'}
 
 const implicitlyTypedPlugin = (settings?: ExamplePluginSettings) => {}
 
+const transformerPlugin =
+  (settings?: ExamplePluginSettings) => (tree: Node, file: vfile.VFile) => tree;
+
 const pluginWithTwoSettings = (
   processor?: Processor,
   settings?: ExamplePluginSettings
@@ -72,6 +75,12 @@ processor.use([[plugin, settings], [implicitlyTypedPlugin, typedSetting]])
 processor.use([implicitlyTypedPlugin])
 processor.use([implicitlyTypedPlugin, settings])
 processor.use([implicitlyTypedPlugin, typedSetting, settings])
+
+processor.use(transformerPlugin)
+processor.use([transformerPlugin, transformerPlugin])
+processor.use(transformerPlugin, typedSetting)
+// $ExpectError
+processor.use(transformerPlugin, settings)
 
 processor.use(pluginWithTwoSettings)
 processor.use(pluginWithTwoSettings).use(pluginWithTwoSettings)


### PR DESCRIPTION
Currently, [the types for this package](https://github.com/unifiedjs/unified/blob/b07233d0c32d47f4acb38cc51ca965e8157230f4/types/index.d.ts#L313) define that Transformers accept a `file` parameter that is `VFileCompatible`. The spec, on the other hand, states the type of the [`file` parameter is a `VFile`](https://github.com/unifiedjs/unified#function-transformernode-file-next).

The current definition is unergonomic because a plugin defined as:

```typescript
export default () => (node: Node, file: VFile) => {
  // ...
};
```

...cannot be passed to `use` since `file: VFile` is incompatible with `file: VFileCompatible` (ironically):

```typescript
import plugin from '...';

unified().use(plugin);
```

causes:

```
Argument of type '() => (tree: Node, file: VFile) => Node' is not assignable to parameter of type 'Attacher<[], Settings>'.
  Type '(tree: Node, file: VFile) => Node' is not assignable to type 'void | Transformer'.
    Type '(tree: Node, file: VFile) => Node' is not assignable to type 'Transformer'.
      Types of parameters 'file' and 'file' are incompatible.
        Type 'VFileCompatible' is not assignable to type 'VFile'.
          Type 'string' is not assignable to type 'VFile'. ts(2345)
```

Even more, existing plugins built on the unified spec expect a `VFile` to be passed without needing to coerce the passed value into a `VFile`, making the current definition inaccurate for these plugins.

This PR fixes this issue by adding some basic tests that make sure this pattern works with `use` & making the necessary 10-character removal to make them pass.