### PR TITLE
Fix Parser and Compiler types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -78,7 +78,7 @@ declare namespace unified {
      *
      * `Parser` can also be a constructor function (a function with keys in its `prototype`) in which case it’s invoked with `new`. Instances must have a parse method which is invoked without arguments and must return a `Node`.
      */
-    Parser: ParserFunction | typeof Parser
+    Parser: ParserConstructor | ParserFunction
 
     /**
      * Compile a syntax tree to text.
@@ -98,7 +98,7 @@ declare namespace unified {
      * `Compiler` can also be a constructor function (a function with keys in its `prototype`) in which case it’s invoked with `new`.
      * Instances must have a `compile` method which is invoked without arguments and must return a `string`.
      */
-    Compiler: CompilerFunction | typeof Compiler
+    Compiler: CompilerConstructor | CompilerFunction
 
     /**
      * Transform a syntax tree by applying plugins to it.
@@ -318,20 +318,32 @@ declare namespace unified {
   /**
    * Transform file contents into an AST
    */
-  class Parser {
+  interface Parser {
     /**
      * Transform file contents into an AST
      *
-     * @param text Text to transfomr into AST node(s)
-     * @param file File associated with text
      * @returns Parsed AST node/tree
      */
-    parse(text: string, file: VFile): Node
+    parse(): Node
+  }
+
+  /**
+   * A constructor function (a function with keys in its `prototype`) or class that implements a
+   * `parse` method.
+   */
+  interface ParserConstructor {
+    /**
+     * Creates a Parser
+     *
+     * @param text Text to transform into AST node(s)
+     * @param file File associated with text
+     */
+    new (text: string, file: VFile): Parser
   }
 
   /**
    * Transform file contents into an AST
-   * 
+   *
    * @param text Text to transform into AST node(s)
    * @param file File associated with text
    * @returns Parsed AST node/tree
@@ -341,15 +353,27 @@ declare namespace unified {
   /**
    * Transform an AST node/tree into text
    */
-  class Compiler {
+  interface Compiler {
     /**
      * Transform an AST node/tree into text
      *
-     * @param node Node/tree to be stringified
-     * @param file File associated with node
      * @returns Compiled text
      */
-    compile(node: Node, file: VFile): string
+    compile(): string
+  }
+
+  /**
+   * A constructor function (a function with keys in its `prototype`) or class that implements a
+   * `compile` method.
+   */
+  interface CompilerConstructor {
+    /**
+     * Creates a Compiler
+     *
+     * @param node Node/tree to be stringified
+     * @param file File associated with node
+     */
+    new (node: Node, file: VFile): Compiler
   }
 
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -322,16 +322,21 @@ declare namespace unified {
     /**
      * Transform file contents into an AST
      *
-     * @param file File to transform into AST node(s)
+     * @param text Text to transfomr into AST node(s)
+     * @param file File associated with text
+     * @returns Parsed AST node/tree
      */
-    parse(file: VFileCompatible): Node
+    parse(text: string, file: VFile): Node
   }
 
   /**
    * Transform file contents into an AST
-   * @param file File to transform into AST node(s)
+   * 
+   * @param text Text to transform into AST node(s)
+   * @param file File associated with text
+   * @returns Parsed AST node/tree
    */
-  type ParserFunction = (file: VFileCompatible) => Node
+  type ParserFunction = (text: string, file: VFile) => Node
 
   /**
    * Transform an AST node/tree into text
@@ -340,21 +345,21 @@ declare namespace unified {
     /**
      * Transform an AST node/tree into text
      *
-     * @param node Node to be stringified
+     * @param node Node/tree to be stringified
      * @param file File associated with node
-     * @returns transformed text
+     * @returns Compiled text
      */
-    compile(node: Node, file?: VFileCompatible): string
+    compile(node: Node, file: VFile): string
   }
 
   /**
    * Transform an AST node/tree into text
    *
-   * @param node Node to be stringified
+   * @param node Node/tree to be stringified
    * @param file File associated with node
-   * @returns transformed text
+   * @returns Compiled text
    */
-  type CompilerFunction = (node: Node, file?: VFileCompatible) => string
+  type CompilerFunction = (node: Node, file: VFile) => string
 
   /**
    * Access results from transforms

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -8,6 +8,7 @@ import {
   ProcessCallback
 } from 'unified'
 import vfile = require('vfile')
+import { VFile } from 'vfile'
 
 let fileValue: vfile.VFile
 let nodeValue: Node
@@ -35,10 +36,9 @@ const typedSetting = {example: 'example'}
 
 const implicitlyTypedPlugin = (settings?: ExamplePluginSettings) => {}
 
-const transformerPlugin = (settings?: ExamplePluginSettings) => (
-  tree: Node,
-  file: vfile.VFile
-) => tree
+const transformerPlugin = (settings?: ExamplePluginSettings) => (tree: Node, file: VFile) => ({
+  type: 'random node'
+})
 
 const pluginWithTwoSettings = (
   processor?: Processor,
@@ -177,11 +177,11 @@ processor.parse(new Buffer('random buffer'))
 /**
  * processor.Parser
  */
-processor.Parser = (file: VFileCompatible) => ({
+processor.Parser = (text: string, file: VFile) => ({
   type: 'random node'
 })
 processor.Parser = class CustomParser {
-  parse(file: VFileCompatible) {
+  parse(text: string, file: VFile): Node {
     return {
       type: 'random node'
     }
@@ -196,11 +196,11 @@ stringValue = processor.stringify(nodeValue)
 /**
  * processor.Compiler
  */
-processor.Compiler = (node: Node, file?: VFileCompatible) => {
+processor.Compiler = (node: Node, file: VFile) => {
   return 'random string'
 }
 processor.Compiler = class CustomCompiler {
-  compile(node: Node, file?: vfile.VFile) {
+  compile(node: Node, file: VFile) {
     return 'random string'
   }
 }

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -8,7 +8,7 @@ import {
   ProcessCallback
 } from 'unified'
 import vfile = require('vfile')
-import { VFile } from 'vfile'
+import {VFile} from 'vfile'
 
 let fileValue: vfile.VFile
 let nodeValue: Node
@@ -36,7 +36,10 @@ const typedSetting = {example: 'example'}
 
 const implicitlyTypedPlugin = (settings?: ExamplePluginSettings) => {}
 
-const transformerPlugin = (settings?: ExamplePluginSettings) => (tree: Node, file: VFile) => ({
+const transformerPlugin = (settings?: ExamplePluginSettings) => (
+  tree: Node,
+  file: VFile
+) => ({
   type: 'random node'
 })
 
@@ -181,7 +184,11 @@ processor.Parser = (text: string, file: VFile) => ({
   type: 'random node'
 })
 processor.Parser = class CustomParser {
-  parse(text: string, file: VFile): Node {
+  constructor(text: string, file: VFile) {
+    // nothing
+  }
+
+  parse(): Node {
     return {
       type: 'random node'
     }
@@ -200,7 +207,11 @@ processor.Compiler = (node: Node, file: VFile) => {
   return 'random string'
 }
 processor.Compiler = class CustomCompiler {
-  compile(node: Node, file: VFile) {
+  constructor(node: Node, file: VFile) {
+    // nothing
+  }
+
+  compile() {
     return 'random string'
   }
 }


### PR DESCRIPTION
The current typings are defined such that [Parsers](https://github.com/unifiedjs/unified#processorparser) and [Compilers](https://github.com/unifiedjs/unified#processorcompiler) (and their respective functional variants) take `VFileCompatible` arguments (and, in the case of Parsers, has the wrong number of arguments). The truth is the spec states that they should accept `VFile` objects (and Parsers take two arguments), and the underlying implementation aligns with this:

* [Parsers are passed a `vfile()`'d argument](https://github.com/unifiedjs/unified/blob/b07233d0c32d47f4acb38cc51ca965e8157230f4/index.js#L270-L274)
* [Compilers are passed a `vfile()`'d argument](https://github.com/unifiedjs/unified/blob/b07233d0c32d47f4acb38cc51ca965e8157230f4/index.js#L340-L344)
* The `file` passed to both is `vfile(doc)` in both.
* Neither type is instantiated/called elsewhere in `index.js`.

Looking for the same inconsistency in the typings, I checked other occurrences of `VFileCompatible` in the `index.d.ts` file. The remaining occurrences align with the spec--that is, anywhere `VFileCompatible` shows up in the typings, the spec explicitly states "any value accepted by `vfile()`".
