### PR TITLE
ci: add GitHub actions continuous integration workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  build-and-test:
+    name: '${{ matrix.platform }}: node.js ${{ matrix.nodejs-version }}'
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+        nodejs-version: [10, 12]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Set up Node.js
+        uses: actions/setup-node@master
+        with:
+          version: ${{ matrix.nodejs-version }}
+      - name: Build and test
+        run: |
+          npm install
+          npm test


### PR DESCRIPTION
Since unified is part of the actions beta, created a ci workflow, to try it out.
based off https://github.com/redotjs/redot/pull/17

:notebook: we already have Travis CI, so this would be a redundancy/backup.