### PR TITLE
ci: add node 13 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [10, 12]
+        node-version: [10, 12, 13]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@master
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Build and test
-        run: |
-          npm install
-          npm test
+      - name: Install
+        run: npm install
+      - name: Test
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "browserify": "^16.0.0",
-    "dtslint": "^0.9.0",
+    "dtslint": "^1.0.2",
     "nyc": "^14.0.0",
     "prettier": "^1.0.0",
     "remark-cli": "^7.0.0",


### PR DESCRIPTION
also split install and tests steps, this groups logs in a way that makes tracking down build failures easier.
