### PR TITLE
[WIP] build: generate commonjs, es module, and umd versions of unified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 .nyc_output/
 coverage/
 node_modules/
-unified.js
-unified.min.js
+dist/
 yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ deploy:
   api_key:
     secure: A16yUNG+m/p98L0mFLIy4IYWJsjWOKujHGEnJ2SwwIGvndLCtIig1BTp3C9Wkwf356UfHwcsPSa95bnpHXEsNZZwsVfzF4Hb2Csn0A9JKrpzoc+VdSgSDl+rUoq71x1TnLn4B2sC6k5/webcU26GBtVfeLka47OIUtuzcn8sxWHDr1JgRtSfVsasO4Iw21bSUnKKrIcgVLBoMrjRbJdCt3yzGaWbr/GuEQ/kXJfFY8zYh1iaJ12Nkqrof1lV766TJPL585uiuXQaHv0u+Hq6MNdKQqN1Tb+CgWB9VJrJaN/DxZpKfsl3FkO21c7UokvWIGP9WV/z5JVDcWhjfH7qRk+joMPYpHzUAlFnOWAz/PTWo0o65hKMrQKSYRxVsmWDSE+0EUV79mOaSUasEPHihXuwzqxrJtkCFW0rAs46Jvu0Z8hLtznH8FuiDU9l3BZsQA8/V5dFJ0Z6yLbvhs0Hwv/+IrLVpeDRixwaaar3EL6RE2zKAharSEgUw78lLkqSI6cDHVsIZVp22kAoeXB3m2JPAO0AAf1EbgZW1RA0kNb8gX3e5AoDsDgRb4ULlCCVXE6EXkH8lfa79Yr+7AUNk3v8orXJ5Qkofzby6js+t3qyTV8+i5T2vHj35lE+hq2KdH5LRVi2+0cmOP+8suJcUq3Two8TKPQXmyIsBOnSQBc=
   file:
-    - 'unified.js'
-    - 'unified.min.js'
+    - 'dist/unified.js'
+    - 'dist/unified.mjs'
+    - 'dist/unified.umd.js'
   on:
     tags: true

--- a/index.js
+++ b/index.js
@@ -1,22 +1,10 @@
 'use strict'
 
-var extend = require('extend')
-var bail = require('bail')
-var vfile = require('vfile')
-var trough = require('trough')
-var plain = require('is-plain-obj')
-
-// Expose a frozen processor.
-module.exports = unified().freeze()
-
-var slice = [].slice
-var own = {}.hasOwnProperty
-
-// Process pipeline.
-var pipeline = trough()
-  .use(pipelineParse)
-  .use(pipelineRun)
-  .use(pipelineStringify)
+import extend from 'extend'
+import bail from 'bail'
+import vfile from 'vfile'
+import trough from 'trough'
+import plain from 'is-plain-obj'
 
 function pipelineParse(p, ctx) {
   ctx.tree = p.parse(ctx.file)
@@ -131,6 +119,8 @@ function unified() {
   // Data management.
   // Getter / setter for processor-specific informtion.
   function data(key, value) {
+    var own = {}.hasOwnProperty
+
     if (typeof key === 'string') {
       // Set `key`.
       if (arguments.length === 2) {
@@ -230,6 +220,7 @@ function unified() {
 
     function addPlugin(plugin, value) {
       var entry = find(plugin)
+      var slice = [].slice
 
       if (entry) {
         if (plain(entry[1]) && plain(value)) {
@@ -361,6 +352,11 @@ function unified() {
 
     function executor(resolve, reject) {
       var file = vfile(doc)
+      // Process pipeline.
+      var pipeline = trough()
+        .use(pipelineParse)
+        .use(pipelineRun)
+        .use(pipelineStringify)
 
       pipeline.run(processor, {file: file}, done)
 
@@ -461,3 +457,6 @@ function assertDone(name, asyncName, complete) {
     )
   }
 }
+
+// Expose a frozen processor.
+export default unified().freeze()

--- a/package.json
+++ b/package.json
@@ -25,11 +25,16 @@
     "Vse Mozhet Byt <vsemozhetbyt@gmail.com>",
     "Richard Littauer <richard.littauer@gmail.com>"
   ],
+  "source": "index.js",
+  "main": "dist/unified.js",
+  "module": "dist/unified.mjs",
+  "unpkg": "dist/unified.umd.js",
   "types": "types/index.d.ts",
+  "sideEffects": false,
   "files": [
     "types/index.d.ts",
     "index.js",
-    "lib"
+    "dist"
   ],
   "dependencies": {
     "bail": "^1.0.0",
@@ -40,31 +45,22 @@
   },
   "devDependencies": {
     "browserify": "^16.0.0",
+    "c8": "^6.0.1",
     "dtslint": "^1.0.2",
-    "nyc": "^14.0.0",
+    "microbundle": "^0.11.0",
     "prettier": "^1.0.0",
     "remark-cli": "^7.0.0",
     "remark-preset-wooorm": "^6.0.0",
     "tape": "^4.0.0",
-    "tinyify": "^2.5.1",
-    "typescript": "^3.0.0",
     "xo": "^0.25.0"
   },
   "scripts": {
-    "format": "remark . -qfo && prettier --write \"**/{*.js,*.ts}\" && xo --fix",
-    "build-bundle": "browserify index.js -s unified -o unified.js",
-    "build-mangle": "browserify index.js -s unified -p tinyify -o unified.min.js",
-    "build": "npm run build-bundle && npm run build-mangle",
+    "format": "remark . -qfo && prettier --write \"index.js\" \"types/**\" && xo --fix",
+    "build": "microbundle",
     "test-api": "node test",
-    "test-coverage": "nyc --reporter lcov tape test",
+    "test-coverage": "c8 --reporter=lcov --check-coverage --lines 100 --functions 100 --branches 100 tape test",
     "test-types": "dtslint types",
     "test": "npm run format && npm run build && npm run test-coverage && npm run test-types"
-  },
-  "nyc": {
-    "check-coverage": true,
-    "lines": 100,
-    "functions": 100,
-    "branches": 100
   },
   "prettier": {
     "tabWidth": 2,


### PR DESCRIPTION
### Goal

Generate several distribution versions for different environments, to allow minimizing downstream tooling to minimize the download/bundle/build size.

### Approach

This leverages [microbundle](https://github.com/developit/microbundle), to generate a common js build for Node, a UMD build for all browsers, and an ES Module build for modern browsers.
Microbundle also minifies the builds and includes a sourcemap for simpler debugging of minified build.

### Alternatives

* Use babel, rollup, webpack, or other build tools to generate distribution versions
* Continue to distribute only a CJS version
* Hand code both a CJS and a ESM version
* Migrate to typescript, use tsc to generate multiple outputs