### PR TITLE
Remove suggestion to install vfile types from `readme.md`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,8 +74,7 @@ npm install unified
 ```
 
 This package comes with types.
-If you’re using TypeScript, make sure to also install [`@types/unist`][ts-unist]
-and [`@types/vfile`][ts-vfile].
+If you’re using TypeScript, make sure to also install [`@types/unist`][ts-unist].
 
 ## Use
 

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,8 @@ npm install unified
 ```
 
 This package comes with types.
-If you’re using TypeScript, make sure to also install [`@types/unist`][ts-unist].
+If you’re using TypeScript, make sure to also install
+[`@types/unist`][ts-unist].
 
 ## Use
 
@@ -1236,8 +1237,6 @@ work on [`ware`][ware], as it was a huge initial inspiration.
 [npm]: https://docs.npmjs.com/cli/install
 
 [ts-unist]: https://www.npmjs.com/package/@types/unist
-
-[ts-vfile]: https://www.npmjs.com/package/@types/vfile
 
 [site]: https://unifiedjs.com
 


### PR DESCRIPTION
vfile now provides its own.

<!--
Read the [contributing guidelines](https://github.com/unifiedjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/unifiedjs/.github/blob/master/support.md
https://github.com/unifiedjs/.github/blob/master/contributing.md
-->
