### PR TITLE
Update Vercel name and logo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,9 +43,9 @@ Some notable users are [Node.js][], [ZEIT][], [Netlify][], [GitHub][],
       <a href="https://www.gatsbyjs.org"><img src="https://avatars1.githubusercontent.com/u/12551863?s=900&v=4"></a>
     </td>
     <td width="33.33%" align="center" colspan="2">
-      <a href="https://zeit.co">ZEIT</a><br>🥇<br><br>
+      <a href="https://vercel.com">Vercel</a><br>🥇<br><br>
       <!--OC has a sharper image-->
-      <a href="https://zeit.co"><img src="https://images.opencollective.com/zeit/d8a5bee/logo/512.png"></a>
+      <a href="https://vercel.com"><img src="https://images.opencollective.com/vercel/7ee187e/logo/512.png"></a>
     </td>
     <td width="33.33%" align="center" colspan="2">
       <a href="https://www.netlify.com">Netlify</a><br>🥇<br><br>


### PR DESCRIPTION
Changes Zeit branding to Vercel branding and uses the OC hosted image with black background.
White background can be found here: https://pbs.twimg.com/profile_images/1252525888710873088/CBm5_MB7_400x400.jpg but makes the logo appear smaller than the other gold sponsors.

<!--
Read the [contributing guidelines](https://github.com/unifiedjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/unifiedjs/.github/blob/master/support.md
https://github.com/unifiedjs/.github/blob/master/contributing.md
-->
