### PR TITLE
types: preset and pluggable list settings type checking

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,7 +27,7 @@ declare namespace unified {
      * @returns The processor on which use is invoked
      */
     use<S extends any[] = [Settings?]>(
-      plugin: Plugin<S, P>,
+      plugin: Plugin<P, S>,
       ...settings: S
     ): Processor<P>
 
@@ -35,8 +35,55 @@ declare namespace unified {
      * Configure the processor with a preset to use
      *
      * @param preset `Object` with an plugins (set to list), and/or an optional settings object
+     * @typeParam S1 Plugin settings
+     * @typeParam S20 Plugin settings
      */
-    use<S extends any[] = [Settings?]>(preset: Preset<S, P>): Processor<P>
+    use<
+      S1 extends any[] = [Settings?],
+      S2 extends any[] = [Settings?],
+      S3 extends any[] = [Settings?],
+      S4 extends any[] = [Settings?],
+      S5 extends any[] = [Settings?],
+      S6 extends any[] = [Settings?],
+      S7 extends any[] = [Settings?],
+      S8 extends any[] = [Settings?],
+      S9 extends any[] = [Settings?],
+      S10 extends any[] = [Settings?],
+      S11 extends any[] = [Settings?],
+      S12 extends any[] = [Settings?],
+      S13 extends any[] = [Settings?],
+      S14 extends any[] = [Settings?],
+      S15 extends any[] = [Settings?],
+      S16 extends any[] = [Settings?],
+      S17 extends any[] = [Settings?],
+      S18 extends any[] = [Settings?],
+      S19 extends any[] = [Settings?],
+      S20 extends any[] = [Settings?]
+    >(
+      preset: Preset<
+        P,
+        S1,
+        S2,
+        S3,
+        S4,
+        S5,
+        S6,
+        S7,
+        S8,
+        S9,
+        S10,
+        S11,
+        S12,
+        S13,
+        S14,
+        S15,
+        S16,
+        S17,
+        S18,
+        S19,
+        S20
+      >
+    ): Processor<P>
 
     /**
      * Configure using a tuple of plugin and setting(s)
@@ -45,15 +92,62 @@ declare namespace unified {
      * @typeParam S Plugin settings
      */
     use<S extends any[] = [Settings?]>(
-      pluginTuple: PluginTuple<S, P>
+      pluginTuple: PluginTuple<P, S>
     ): Processor<P>
 
     /**
      * A list of plugins and presets to be applied to processor
      *
      * @param list List of plugins, presets, and pairs
+     * @typeParam S1 Plugin settings
+     * @typeParam S20 Plugin settings
      */
-    use(list: PluggableList<P>): Processor<P>
+    use<
+      S1 extends any[] = [Settings?],
+      S2 extends any[] = [Settings?],
+      S3 extends any[] = [Settings?],
+      S4 extends any[] = [Settings?],
+      S5 extends any[] = [Settings?],
+      S6 extends any[] = [Settings?],
+      S7 extends any[] = [Settings?],
+      S8 extends any[] = [Settings?],
+      S9 extends any[] = [Settings?],
+      S10 extends any[] = [Settings?],
+      S11 extends any[] = [Settings?],
+      S12 extends any[] = [Settings?],
+      S13 extends any[] = [Settings?],
+      S14 extends any[] = [Settings?],
+      S15 extends any[] = [Settings?],
+      S16 extends any[] = [Settings?],
+      S17 extends any[] = [Settings?],
+      S18 extends any[] = [Settings?],
+      S19 extends any[] = [Settings?],
+      S20 extends any[] = [Settings?]
+    >(
+      list: PluggableList<
+        P,
+        S1,
+        S2,
+        S3,
+        S4,
+        S5,
+        S6,
+        S7,
+        S8,
+        S9,
+        S10,
+        S11,
+        S12,
+        S13,
+        S14,
+        S15,
+        S16,
+        S17,
+        S18,
+        S19,
+        S20
+      >
+    ): Processor<P>
 
     /**
      * Configuration passed to a frozen processor
@@ -210,11 +304,11 @@ declare namespace unified {
    * Attachers can configure processors, such as by interacting with parsers and compilers, linking them to other processors, or by specifying how the syntax tree is handled.
    *
    * @param settings Configuration
-   * @typeParam S Plugin settings
    * @typeParam P Processor settings
+   * @typeParam S Plugin settings
    * @returns Optional Transformer.
    */
-  type Plugin<S extends any[] = [Settings?], P = Settings> = Attacher<S, P>
+  type Plugin<P = Settings, S extends any[] = [Settings?]> = Attacher<P, S>
 
   /**
    * Configuration passed to a Plugin or Processor
@@ -228,9 +322,55 @@ declare namespace unified {
    * They can contain multiple plugins and optionally settings as well.
    *
    * @typeParam P Processor settings
+   * @typeParam S1 Plugin settings
+   * @typeParam S20 Plugin settings
    */
-  interface Preset<S = Settings, P = Settings> {
-    plugins: PluggableList<P>
+  interface Preset<
+    P = Settings,
+    S1 extends any[] = [Settings?],
+    S2 extends any[] = [Settings?],
+    S3 extends any[] = [Settings?],
+    S4 extends any[] = [Settings?],
+    S5 extends any[] = [Settings?],
+    S6 extends any[] = [Settings?],
+    S7 extends any[] = [Settings?],
+    S8 extends any[] = [Settings?],
+    S9 extends any[] = [Settings?],
+    S10 extends any[] = [Settings?],
+    S11 extends any[] = [Settings?],
+    S12 extends any[] = [Settings?],
+    S13 extends any[] = [Settings?],
+    S14 extends any[] = [Settings?],
+    S15 extends any[] = [Settings?],
+    S16 extends any[] = [Settings?],
+    S17 extends any[] = [Settings?],
+    S18 extends any[] = [Settings?],
+    S19 extends any[] = [Settings?],
+    S20 extends any[] = [Settings?]
+  > {
+    plugins: PluggableList<
+      P,
+      S1,
+      S2,
+      S3,
+      S4,
+      S5,
+      S6,
+      S7,
+      S8,
+      S9,
+      S10,
+      S11,
+      S12,
+      S13,
+      S14,
+      S15,
+      S16,
+      S17,
+      S18,
+      S19,
+      S20
+    >
     settings?: Settings
   }
 
@@ -246,31 +386,122 @@ declare namespace unified {
   /**
    * A pairing of a plugin with its settings
    *
-   * @typeParam S Plugin settings
    * @typeParam P Processor settings
+   * @typeParam S Plugin settings
    */
-  type PluginTuple<S extends any[] = [Settings?], P = Settings> = [
-    Plugin<S, P>,
+  type PluginTuple<P = Settings, S extends any[] = [Settings?]> = [
+    Plugin<P, S>,
     ...S
   ]
 
   /**
    * A union of the different ways to add plugins to unified
    *
-   * @typeParam S Plugin settings
    * @typeParam P Processor settings
+   * @typeParam S1 Plugin settings
+   * @typeParam S20 Plugin settings
    */
-  type Pluggable<S extends any[] = [Settings?], P = Settings> =
-    | Plugin<S, P>
-    | Preset<S, P>
-    | PluginTuple<S, P>
+  type Pluggable<
+    P = Settings,
+    S1 extends any[] = [Settings?],
+    S2 extends any[] = [Settings?],
+    S3 extends any[] = [Settings?],
+    S4 extends any[] = [Settings?],
+    S5 extends any[] = [Settings?],
+    S6 extends any[] = [Settings?],
+    S7 extends any[] = [Settings?],
+    S8 extends any[] = [Settings?],
+    S9 extends any[] = [Settings?],
+    S10 extends any[] = [Settings?],
+    S11 extends any[] = [Settings?],
+    S12 extends any[] = [Settings?],
+    S13 extends any[] = [Settings?],
+    S14 extends any[] = [Settings?],
+    S15 extends any[] = [Settings?],
+    S16 extends any[] = [Settings?],
+    S17 extends any[] = [Settings?],
+    S18 extends any[] = [Settings?],
+    S19 extends any[] = [Settings?],
+    S20 extends any[] = [Settings?]
+  > =
+    | Plugin<P, S1>
+    | PluginTuple<P, S1>
+    | Preset<
+        P,
+        S1,
+        S2,
+        S3,
+        S4,
+        S5,
+        S6,
+        S7,
+        S8,
+        S9,
+        S10,
+        S11,
+        S12,
+        S13,
+        S14,
+        S15,
+        S16,
+        S17,
+        S18,
+        S19,
+        S20
+      >
 
   /**
    * A list of plugins and presets
    *
    * @typeParam P Processor settings
+   * @typeParam S1 Plugin settings
+   * @typeParam S20 Plugin settings
    */
-  type PluggableList<P = Settings> = Array<Pluggable<any[], P>>
+  type PluggableList<
+    P = Settings,
+    S1 extends any[] = [Settings?],
+    S2 extends any[] = [Settings?],
+    S3 extends any[] = [Settings?],
+    S4 extends any[] = [Settings?],
+    S5 extends any[] = [Settings?],
+    S6 extends any[] = [Settings?],
+    S7 extends any[] = [Settings?],
+    S8 extends any[] = [Settings?],
+    S9 extends any[] = [Settings?],
+    S10 extends any[] = [Settings?],
+    S11 extends any[] = [Settings?],
+    S12 extends any[] = [Settings?],
+    S13 extends any[] = [Settings?],
+    S14 extends any[] = [Settings?],
+    S15 extends any[] = [Settings?],
+    S16 extends any[] = [Settings?],
+    S17 extends any[] = [Settings?],
+    S18 extends any[] = [Settings?],
+    S19 extends any[] = [Settings?],
+    S20 extends any[] = [Settings?]
+  > = [
+    Pluggable<P, S1>?,
+    Pluggable<P, S2>?,
+    Pluggable<P, S3>?,
+    Pluggable<P, S4>?,
+    Pluggable<P, S5>?,
+    Pluggable<P, S6>?,
+    Pluggable<P, S7>?,
+    Pluggable<P, S8>?,
+    Pluggable<P, S9>?,
+    Pluggable<P, S10>?,
+    Pluggable<P, S11>?,
+    Pluggable<P, S12>?,
+    Pluggable<P, S13>?,
+    Pluggable<P, S14>?,
+    Pluggable<P, S15>?,
+    Pluggable<P, S16>?,
+    Pluggable<P, S17>?,
+    Pluggable<P, S18>?,
+    Pluggable<P, S19>?,
+    Pluggable<P, S20>?,
+    ...Array<Pluggable<P, any[]>>
+  ]
 
   /**
    * An attacher is the thing passed to `use`.
@@ -279,11 +510,12 @@ declare namespace unified {
    * Attachers can configure processors, such as by interacting with parsers and compilers, linking them to other processors, or by specifying how the syntax tree is handled.
    *
    * @param settings Configuration
-   * @typeParam S Plugin settings
    * @typeParam P Processor settings
+   * @typeParam S1 Plugin settings
+   * @typeParam S20 Plugin settings
    * @returns Optional Transformer.
    */
-  type Attacher<S extends any[] = [Settings?], P = Settings> = (
+  type Attacher<P = Settings, S extends any[] = [Settings?]> = (
     this: Processor<P>,
     ...settings: S
   ) => Transformer | void

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,7 @@
-// TypeScript Version: 3.4
+// TypeScript Version: 4.0
 
 import {Node} from 'unist'
-import {VFile, VFileContents, VFileOptions, VFileCompatible} from 'vfile'
-import vfile = require('vfile')
+import {VFile, VFileCompatible} from 'vfile'
 
 declare namespace unified {
   /**
@@ -252,12 +251,7 @@ declare namespace unified {
    */
   type PluginTuple<S extends any[] = [Settings?], P = Settings> = [
     Plugin<S, P>,
-    /**
-     * NOTE: ideally this would be S instead of any[]
-     * As of TypeScript 3.5.2 generic tuples cannot be spread
-     * See: https://github.com/microsoft/TypeScript/issues/26113
-     */
-    ...any[]
+    ...S
   ]
 
   /**
@@ -276,7 +270,7 @@ declare namespace unified {
    *
    * @typeParam P Processor settings
    */
-  type PluggableList<P = Settings> = Array<Pluggable<[any?], P>>
+  type PluggableList<P = Settings> = Array<Pluggable<any[], P>>
 
   /**
    * An attacher is the thing passed to `use`.

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -25,7 +25,7 @@ const settings = {
 interface ExamplePluginSettings {
   example: string
 }
-const typedPlugin: Plugin<[ExamplePluginSettings?]> = function () {}
+const typedPlugin: Plugin<unknown, [ExamplePluginSettings?]> = function () {}
 const typedSetting = {example: 'example'}
 
 const implicitlyTypedPlugin = (settings?: ExamplePluginSettings) => {}
@@ -113,6 +113,11 @@ processor.use([typedPlugin, typedSetting])
 processor.use([typedPlugin, typedSetting, settings])
 // $ExpectError
 processor.use([typedPlugin, settings])
+// $ExpectError
+processor.use([
+  [plugin, settings],
+  [typedPlugin, settings]
+])
 
 processor.use(implicitlyTypedPlugin)
 processor.use(implicitlyTypedPlugin).use(implicitlyTypedPlugin)
@@ -132,6 +137,11 @@ processor.use([implicitlyTypedPlugin, typedSetting])
 processor.use([implicitlyTypedPlugin, settings])
 // $ExpectError
 processor.use([implicitlyTypedPlugin, typedSetting, settings])
+// $ExpectError
+processor.use([
+  [implicitlyTypedPlugin, settings],
+  [implicitlyTypedPlugin, typedSetting]
+])
 
 processor.use(transformerPlugin)
 processor.use([transformerPlugin, transformerPlugin])
@@ -149,6 +159,11 @@ processor.use([pluginWithTwoSettings, processor, typedSetting])
 processor.use([pluginWithTwoSettings, processor])
 processor.use([
   [pluginWithTwoSettings, processor, typedSetting],
+  [pluginWithTwoSettings, processor, typedSetting]
+])
+// $ExpectError
+processor.use([
+  [pluginWithTwoSettings, processor, settings],
   [pluginWithTwoSettings, processor, typedSetting]
 ])
 processor.use([
@@ -354,5 +369,9 @@ remark.use(function () {
     // $ExpectError
     .use({settings: {dne: true}})
 })
+remark.use(typedPlugin);
+remark.use(implicitlyTypedPlugin);
+// $ExpectError
+remark.use(plugin);
 // $ExpectError
 remark.use({})

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -98,7 +98,6 @@ processor.use([
 processor.use(typedPlugin)
 processor.use(typedPlugin).use(typedPlugin)
 processor.use(typedPlugin, typedSetting)
-// NOTE: in tuple/array form settings are not able to be type checked
 processor.use([typedPlugin, typedSetting])
 processor.use([
   [typedPlugin, typedSetting],
@@ -109,13 +108,15 @@ processor.use([
   [typedPlugin, typedSetting]
 ])
 processor.use([typedPlugin])
+processor.use([typedPlugin, typedSetting])
+// $ExpectError
 processor.use([typedPlugin, typedSetting, settings])
+// $ExpectError
 processor.use([typedPlugin, settings])
 
 processor.use(implicitlyTypedPlugin)
 processor.use(implicitlyTypedPlugin).use(implicitlyTypedPlugin)
 processor.use(implicitlyTypedPlugin, typedSetting)
-// NOTE: in tuple/array form settings are not able to be type checked
 processor.use([implicitlyTypedPlugin, typedSetting])
 processor.use([
   [implicitlyTypedPlugin, typedSetting],
@@ -126,7 +127,10 @@ processor.use([
   [implicitlyTypedPlugin, typedSetting]
 ])
 processor.use([implicitlyTypedPlugin])
+processor.use([implicitlyTypedPlugin, typedSetting])
+// $ExpectError
 processor.use([implicitlyTypedPlugin, settings])
+// $ExpectError
 processor.use([implicitlyTypedPlugin, typedSetting, settings])
 
 processor.use(transformerPlugin)
@@ -139,7 +143,7 @@ processor.use(pluginWithTwoSettings)
 processor.use(pluginWithTwoSettings).use(pluginWithTwoSettings)
 processor.use(pluginWithTwoSettings, processor, typedSetting)
 processor.use(pluginWithTwoSettings, processor)
-// NOTE: in tuple/array form settings are not able to be type checked
+// $ExpectError
 processor.use([pluginWithTwoSettings, processor, settings])
 processor.use([pluginWithTwoSettings, processor, typedSetting])
 processor.use([pluginWithTwoSettings, processor])


### PR DESCRIPTION
builds on #91 

allow pluggable list and preset to check settings on first 20 elements

leverages variadic typing and generics to allow the first 20 plugins to have full settings type checking.
plugins after the first twenty can still be added, but no longer have their settings checked.

BREAKING CHANGE: changes to order of the processor settings generic `P`, to go first and plugin settings `S` to go after. Plugins directly using the `Plugin` or `Attacher` type will need to add the first generic with the processor settings.
NOTE: If the plugin does not directly use the `Plugin` or `Attacher` type it may not need to migrate. For example
```ts
// this does NOT need to migrate, it will continue to work
const plugin = () => (settings: Settings) => { /* ... */ }

// this DOES need to migrate, settings would passed to the wrong generic parameter
const plugin: Plugin<[Settings?]> = () => (settings: Settings) => { /* ... */ }
```
MIGRATION: if `this` is not used in the plugin, set the first generic to `unknown`
For example
```typescript
Plugin<[PluginSettings?]>
// becomes
Plugin<unknown, [PluginSettings?]>

// and

Attacher<[PluginSettings?]>
// becomes
Attacher<unknown, [PluginSettings?]>
```
if it does depend on `this`, add the processor options in the first generic, for example `RemarkOptions` or `RehypeOptions` could be used.

:warning: TypeScript 4 is currently in beta, this should not be merged until after there is a stable release.
:warning: Adopting this change would require migration of some plugins' typing

---

Additional Discussion:
1. Is there a way to support an artibrary number of plugins in `PluggableList`? Pointers on the syntax for that would be welcome!
2. Should `Attacher` and `Plugin` keep their current generic order? This would reduce the need for migration, but would introduce incosistency between generic parameter order for `Attacher` and  `Plugin` vs `PluggableList` and `Preset`