### PR TITLE
Add `FrozenProcessor` interface to types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -57,7 +57,7 @@ declare namespace unified {
   }
 
   /**
-   * A frozen processor is just like a regular processor, except no additional plugins can’t be added.
+   * A frozen processor is just like a regular processor, except no additional plugins can be added.
    * A frozen processor can be created by calling `.freeze()` on a processor.
    *
    * @see Processor

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,15 +10,7 @@ declare namespace unified {
    *
    * @typeParam P Processor settings. Useful when packaging unified with a preset parser and compiler.
    */
-  interface Processor<P = Settings> {
-    /**
-     * Clone current processor
-     *
-     * @returns New unfrozen processor which is configured to function the same as its ancestor.
-     * But when the descendant processor is configured in the future it does not affect the ancestral processor.
-     */
-    (): Processor<P>
-
+  interface Processor<P = Settings> extends FrozenProcessor<P> {
     /**
      * Configure the processor to use a plugin and optionally configure that plugin with options.
      *
@@ -62,6 +54,22 @@ declare namespace unified {
      * @param processorSettings Settings passed to processor
      */
     use(processorSettings: ProcessorSettings<P>): Processor<P>
+  }
+
+  /**
+   * A frozen processor is just like a regular processor, except no additional plugins can’t be added.
+   * A frozen processor can be created by calling `.freeze()` on a processor.
+   *
+   * @see Processor
+   */
+  interface FrozenProcessor<P = Settings> {
+    /**
+     * Clone current processor
+     *
+     * @returns New unfrozen processor which is configured to function the same as its ancestor.
+     * But when the descendant processor is configured in the future it does not affect the ancestral processor.
+     */
+    (): Processor<P>
 
     /**
      * Parse text to a syntax tree.
@@ -201,7 +209,7 @@ declare namespace unified {
      *
      * @returns The processor on which freeze is invoked.
      */
-    freeze(): Processor<P>
+    freeze(): FrozenProcessor<P>
   }
 
   /**

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -11,7 +11,7 @@ let stringValue: string
 /**
  * `processor()`
  */
-let processor: Processor = unified()
+const processor: Processor = unified()
 const clonedProcessor: Processor = processor()
 
 /**
@@ -321,7 +321,9 @@ unknownValue = processor.data().randomKey
 /**
  * `processor.freeze`
  */
-processor = processor.freeze()
+const frozenProcessor = processor.freeze()
+// $ExpectError
+frozenProcessor.use(plugin)
 
 /**
  * Language specific processors
@@ -333,15 +335,16 @@ interface RemarkSettings {
 const remark = unified<RemarkSettings>()
   .use(() => {})
   .freeze()
-remark
+remark.parse('# Hello markdown')
+remark()
   .use({settings: {gfm: true}})
   // $ExpectError
   .use({settings: {dne: true}})
-remark
+remark()
   // $ExpectError
   .use({settings: {dne: true}})
   .use({settings: {gfm: true}})
-remark.use(function () {
+remark().use(function () {
   this
     // $ExpectError
     .use({settings: {dne: true}})


### PR DESCRIPTION
A frozen processor has the same interface as a regular processor, except `use()`
is always disallowed.

This is related to remarkjs/remark#513