### PR TITLE
Define input and output types for transformers

### DIFF
--- a/types/ts3.4/index.d.ts
+++ b/types/ts3.4/index.d.ts
@@ -18,8 +18,12 @@ declare namespace unified {
      * @typeParam S Plugin settings
      * @returns The processor on which use is invoked
      */
-    use<S extends any[] = [Settings?]>(
-      plugin: Plugin<S, P>,
+    use<
+      S extends any[] = [Settings?],
+      I extends Node = Node,
+      O extends Node = I
+    >(
+      plugin: Plugin<S, P, I, O>,
       ...settings: S
     ): Processor<P>
 
@@ -222,7 +226,12 @@ declare namespace unified {
    * @typeParam P Processor settings
    * @returns Optional Transformer.
    */
-  type Plugin<S extends any[] = [Settings?], P = Settings> = Attacher<S, P>
+  type Plugin<
+    S extends any[] = [Settings?],
+    P = Settings,
+    I extends Node = Node,
+    O extends Node = I
+  > = Attacher<S, P, I, O>
 
   /**
    * Configuration passed to a Plugin or Processor
@@ -296,10 +305,12 @@ declare namespace unified {
    * @typeParam P Processor settings
    * @returns Optional Transformer.
    */
-  type Attacher<S extends any[] = [Settings?], P = Settings> = (
-    this: Processor<P>,
-    ...settings: S
-  ) => Transformer | void
+  type Attacher<
+    S extends any[] = [Settings?],
+    P = Settings,
+    I extends Node = Node,
+    O extends Node = I
+  > = (this: Processor<P>, ...settings: S) => Transformer<I, O> | void
 
   /**
    * Transformers modify the syntax tree or metadata of a file. A transformer is a function which is invoked each time a file is passed through the transform phase.
@@ -316,15 +327,17 @@ declare namespace unified {
    * - `Node` — Can be returned and results in further transformations and `stringify`s to be performed on the new tree
    * - `Promise` — If a promise is returned, the function is asynchronous, and must be resolved (optionally with a `Node`) or rejected (optionally with an `Error`)
    */
-  type Transformer = (
-    node: Node,
+  type Transformer<I extends Node = Node, O extends Node = I> = (
+    node: I,
     file: VFile,
     next?: (
       error: Error | null,
       tree: Node,
       file: VFile
     ) => Record<string, unknown>
-  ) => Error | Node | Promise<Node> | void | Promise<void>
+  ) => O extends I
+    ? Error | O | Promise<O> | void | Promise<void>
+    : Error | O | Promise<O>
 
   /**
    * Transform file contents into an AST

--- a/types/ts3.4/tslint.json
+++ b/types/ts3.4/tslint.json
@@ -7,6 +7,7 @@
     "only-arrow-functions": false,
     "semicolon": false,
     "unified-signatures": false,
+    "void-return": false,
     "whitespace": false
   }
 }

--- a/types/ts3.4/unified-tests.ts
+++ b/types/ts3.4/unified-tests.ts
@@ -325,6 +325,83 @@ const frozenProcessor = processor.freeze()
 // $ExpectError
 frozenProcessor.use(plugin)
 
+interface MDastRoot extends Node {
+  type: 'mdast-root'
+}
+
+interface HastRoot extends Node {
+  type: 'hast-root'
+}
+
+const returnTransformer: unified.Transformer<MDastRoot> = (ast) => {
+  // $ExpectType MDastRoot
+  ast
+  return ast
+}
+
+const voidTransformer: unified.Transformer<MDastRoot> = (ast) => {
+  // $ExpectType MDastRoot
+  ast
+}
+
+// $ExpectError
+const invalidReturnRemarkRehypeTransformer: unified.Transformer<
+  MDastRoot,
+  HastRoot
+> = (ast) => {
+  return ast
+}
+
+// $ExpectError
+const invalidVoidRemarkRehypeTransformer: unified.Transformer<
+  MDastRoot,
+  HastRoot
+> = (ast) => {}
+
+const remarkRehypeTransformer: unified.Transformer<MDastRoot, HastRoot> = (
+  ast
+) => {
+  return {type: 'hast-root'}
+}
+
+const returnAttacher: unified.Plugin<any[], any, MDastRoot> = () => (ast) => {
+  // $ExpectType MDastRoot
+  ast
+  return ast
+}
+
+const voidAttacher: unified.Plugin<any[], any, MDastRoot> = () => (ast) => {
+  // $ExpectType MDastRoot
+  ast
+}
+
+const invalidReturnRemarkRehypeAttacher: unified.Plugin<
+  any[],
+  any,
+  MDastRoot,
+  HastRoot
+  // $ExpectError
+> = () => (ast) => {
+  return ast
+}
+
+const invalidVoidRemarkRehypeAttacher: unified.Plugin<
+  any[],
+  any,
+  MDastRoot,
+  HastRoot
+  // $ExpectError
+> = () => (ast) => {}
+
+const remarkRehypeAttacher: unified.Plugin<
+  any[],
+  any,
+  MDastRoot,
+  HastRoot
+> = () => (ast) => {
+  return {type: 'hast-root'}
+}
+
 /**
  * Language specific processors
  */
@@ -353,5 +430,11 @@ remark().use(function () {
     // $ExpectError
     .use({settings: {dne: true}})
 })
+remark()
+  .use(returnAttacher)
+  .use(voidAttacher)
+  .use(invalidReturnRemarkRehypeAttacher)
+  .use(invalidVoidRemarkRehypeAttacher)
+  .use(remarkRehypeAttacher)
 // $ExpectError
 remark.use({})

--- a/types/ts4.0/index.d.ts
+++ b/types/ts4.0/index.d.ts
@@ -18,8 +18,12 @@ declare namespace unified {
      * @typeParam S Plugin settings
      * @returns The processor on which use is invoked
      */
-    use<S extends any[] = [Settings?]>(
-      plugin: Plugin<S, P>,
+    use<
+      S extends any[] = [Settings?],
+      I extends Node = Node,
+      O extends Node = I
+    >(
+      plugin: Plugin<S, P, I, O>,
       ...settings: S
     ): Processor<P>
 
@@ -222,7 +226,12 @@ declare namespace unified {
    * @typeParam P Processor settings
    * @returns Optional Transformer.
    */
-  type Plugin<S extends any[] = [Settings?], P = Settings> = Attacher<S, P>
+  type Plugin<
+    S extends any[] = [Settings?],
+    P = Settings,
+    I extends Node = Node,
+    O extends Node = I
+  > = Attacher<S, P, I, O>
 
   /**
    * Configuration passed to a Plugin or Processor
@@ -291,10 +300,12 @@ declare namespace unified {
    * @typeParam P Processor settings
    * @returns Optional Transformer.
    */
-  type Attacher<S extends any[] = [Settings?], P = Settings> = (
-    this: Processor<P>,
-    ...settings: S
-  ) => Transformer | void
+  type Attacher<
+    S extends any[] = [Settings?],
+    P = Settings,
+    I extends Node = Node,
+    O extends Node = I
+  > = (this: Processor<P>, ...settings: S) => Transformer<I, O> | void
 
   /**
    * Transformers modify the syntax tree or metadata of a file. A transformer is a function which is invoked each time a file is passed through the transform phase.
@@ -311,15 +322,17 @@ declare namespace unified {
    * - `Node` — Can be returned and results in further transformations and `stringify`s to be performed on the new tree
    * - `Promise` — If a promise is returned, the function is asynchronous, and must be resolved (optionally with a `Node`) or rejected (optionally with an `Error`)
    */
-  type Transformer = (
-    node: Node,
+  type Transformer<I extends Node = Node, O extends Node = I> = (
+    node: I,
     file: VFile,
     next?: (
       error: Error | null,
       tree: Node,
       file: VFile
     ) => Record<string, unknown>
-  ) => Error | Node | Promise<Node> | void | Promise<void>
+  ) => O extends I
+    ? Error | O | Promise<O> | void | Promise<void>
+    : Error | O | Promise<O>
 
   /**
    * Transform file contents into an AST

--- a/types/ts4.0/tslint.json
+++ b/types/ts4.0/tslint.json
@@ -7,6 +7,7 @@
     "only-arrow-functions": false,
     "semicolon": false,
     "unified-signatures": false,
+    "void-return": false,
     "whitespace": false
   }
 }

--- a/types/ts4.0/unified-tests.ts
+++ b/types/ts4.0/unified-tests.ts
@@ -329,6 +329,83 @@ const frozenProcessor = processor.freeze()
 // $ExpectError
 frozenProcessor.use(plugin)
 
+interface MDastRoot extends Node {
+  type: 'mdast-root'
+}
+
+interface HastRoot extends Node {
+  type: 'hast-root'
+}
+
+const returnTransformer: unified.Transformer<MDastRoot> = (ast) => {
+  // $ExpectType MDastRoot
+  ast
+  return ast
+}
+
+const voidTransformer: unified.Transformer<MDastRoot> = (ast) => {
+  // $ExpectType MDastRoot
+  ast
+}
+
+// $ExpectError
+const invalidReturnRemarkRehypeTransformer: unified.Transformer<
+  MDastRoot,
+  HastRoot
+> = (ast) => {
+  return ast
+}
+
+// $ExpectError
+const invalidVoidRemarkRehypeTransformer: unified.Transformer<
+  MDastRoot,
+  HastRoot
+> = (ast) => {}
+
+const remarkRehypeTransformer: unified.Transformer<MDastRoot, HastRoot> = (
+  ast
+) => {
+  return {type: 'hast-root'}
+}
+
+const returnAttacher: unified.Plugin<any[], any, MDastRoot> = () => (ast) => {
+  // $ExpectType MDastRoot
+  ast
+  return ast
+}
+
+const voidAttacher: unified.Plugin<any[], any, MDastRoot> = () => (ast) => {
+  // $ExpectType MDastRoot
+  ast
+}
+
+const invalidReturnRemarkRehypeAttacher: unified.Plugin<
+  any[],
+  any,
+  MDastRoot,
+  HastRoot
+  // $ExpectError
+> = () => (ast) => {
+  return ast
+}
+
+const invalidVoidRemarkRehypeAttacher: unified.Plugin<
+  any[],
+  any,
+  MDastRoot,
+  HastRoot
+  // $ExpectError
+> = () => (ast) => {}
+
+const remarkRehypeAttacher: unified.Plugin<
+  any[],
+  any,
+  MDastRoot,
+  HastRoot
+> = () => (ast) => {
+  return {type: 'hast-root'}
+}
+
 /**
  * Language specific processors
  */
@@ -357,5 +434,11 @@ remark().use(function () {
     // $ExpectError
     .use({settings: {dne: true}})
 })
+remark()
+  .use(returnAttacher)
+  .use(voidAttacher)
+  .use(invalidReturnRemarkRehypeAttacher)
+  .use(invalidVoidRemarkRehypeAttacher)
+  .use(remarkRehypeAttacher)
 // $ExpectError
 remark.use({})


### PR DESCRIPTION
This allows to transform this code:

```ts
import * as hast from 'hast';
import * as mdast from 'mdast';
import * as unist from 'unist';

const remarkRehype: Plugin<[RemarkRehypeOptions?]> = () => (ast) => {
  const markdown = ast as mdast.Root;
  const html = transform(markdown);
  return html as unist.Root;
};
```

into:

```ts
import * as hast from 'hast';
import * as mdast from 'mdast';
import * as unist from 'unist';

const remarkRehype: Plugin<[RemarkRehypeOptions?], unknown, mdast.Root, hast.Root> = () => (ast) {
  const html = transform(ast);
  return html;
}
```

Unified processors can’t be properly typed due to their mutable nature. This means there’s no real point in specifying these types for packages written in JavaScript and contain separate type definitions. However, this is useful for unified plugins that are written in TypeScript themselves.