### PR TITLE
#55: swapped is-plain-obj for is-plain-object

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var bail = require('bail')
 var buffer = require('is-buffer')
 var extend = require('extend')
-var plain = require('is-plain-obj')
+var {isPlainObject} = require('is-plain-object')
 var trough = require('trough')
 var vfile = require('vfile')
 
@@ -229,7 +229,7 @@ function unified() {
       var entry = find(plugin)
 
       if (entry) {
-        if (plain(entry[1]) && plain(value)) {
+        if (isPlainObject(entry[1]) && isPlainObject(value)) {
           value = extend(true, entry[1], value)
         }
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bail": "^1.0.0",
     "extend": "^3.0.0",
     "is-buffer": "^2.0.0",
-    "is-plain-obj": "^2.0.0",
+    "is-plain-object": "^5.0.0",
     "trough": "^1.0.0",
     "vfile": "^4.0.0"
   },


### PR DESCRIPTION
Closes GH-55.

I have read the [comment thread](https://github.com/unifiedjs/unified/issues/55#issuecomment-506920290) and seen [the open PR](https://github.com/unifiedjs/unifiedjs.github.io/pull/9) regarding the docs for transpiling individual node_modules. We have it working on our specific project with this technique.

However we have created our own internal library which is shared in a large organisation across multiple teams, all of whom need to support IE11. Because our internal library includes remark, unified and thus **is-plain-obj**, every team will have to make this change in their build tooling to transpile `node_modules/is-plain-obj`.

We would very much appreciate it if you were to swap out the libraries, as it is the simplest of changes and makes unified work in IE11 straight out of the box.
