### PR TITLE
55: upgraded is-plain-obj

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bail": "^1.0.0",
     "extend": "^3.0.0",
     "is-buffer": "^2.0.0",
-    "is-plain-obj": "^2.0.0",
+    "is-plain-obj": "^4.0.0",
     "trough": "^1.0.0",
     "vfile": "^4.0.0"
   },


### PR DESCRIPTION
I'll try again @ChristianMurphy :)

@sindresorhus has upgraded is-plain-obj to no longer use `=>` notation, which resolves both of our issues.
https://github.com/sindresorhus/is-plain-obj/blob/main/index.js

Fixes #55 