### PR TITLE
Fix code-style

### DIFF
--- a/test/freeze.js
+++ b/test/freeze.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var test = require('tape')
-var simple = require('./util/simple')
+var simple = require('./util/simple.js')
 var unified = require('..')
 
 test('freeze()', function (t) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,14 +1,14 @@
 'use strict'
 
 /* eslint-disable import/no-unassigned-import */
-require('./core')
-require('./freeze')
-require('./data')
-require('./use')
-require('./parse')
-require('./run')
-require('./stringify')
-require('./process')
+require('./core.js')
+require('./freeze.js')
+require('./data.js')
+require('./use.js')
+require('./parse.js')
+require('./run.js')
+require('./stringify.js')
+require('./process.js')
 
 var asyncfunctions = false
 
@@ -19,7 +19,7 @@ try {
 
 console.log('asyncfunctions:', asyncfunctions)
 if (asyncfunctions) {
-  require('./async-function')
+  require('./async-function.js')
 }
 
 /* eslint-enable import/no-unassigned-import */

--- a/test/process.js
+++ b/test/process.js
@@ -2,8 +2,8 @@
 
 var test = require('tape')
 var vfile = require('vfile')
-var simple = require('./util/simple')
-var noop = require('./util/noop')
+var simple = require('./util/simple.js')
+var noop = require('./util/noop.js')
 var unified = require('..')
 
 test('process(file, done)', function (t) {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -2,7 +2,7 @@
 
 var test = require('tape')
 var vfile = require('vfile')
-var noop = require('./util/noop')
+var noop = require('./util/noop.js')
 var unified = require('..')
 
 test('stringify(node[, file])', function (t) {


### PR DESCRIPTION
Hey, there.

Currently `npm test` throws the following error:

  test/index.js:4:9
  ✖   4:9   Missing file extension for "./core"            import/extensions
  ✖   5:9   Missing file extension for "./freeze"          import/extensions
   ...
  13 errors

This pull request fixes those errors and now all tests pass.
Hope you find this useful.