### PR TITLE
Fix to set `vfile.value` if a vfile@5 is given

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,5 +20,5 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node:
-          - lts/dubnium
+          - lts/erbium
           - node

--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ function pipelineStringify(p, ctx) {
   if (result === undefined || result === null) {
     // Empty.
   } else if (typeof result === 'string' || buffer(result)) {
+    if ('value' in ctx.file) {
+      ctx.file.value = result
+    }
+
     ctx.file.contents = result
   } else {
     ctx.file.result = result

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "vfile": "^4.0.0"
   },
   "devDependencies": {
+    "vfile5": "npm:vfile@5",
     "browserify": "^17.0.0",
     "c8": "^7.0.0",
     "dtslint": "^4.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ require('./parse.js')
 require('./run.js')
 require('./stringify.js')
 require('./process.js')
+require('./vfile-5.js')
 
 var asyncfunctions = false
 

--- a/test/vfile-5.js
+++ b/test/vfile-5.js
@@ -1,0 +1,29 @@
+'use strict'
+
+var test = require('tape')
+var simple = require('./util/simple.js')
+var unified = require('..')
+
+test('vfile@5', async function (t) {
+  t.plan(2)
+
+  var pipeline = unified().use(function () {
+    this.Parser = simple.Parser
+    this.Compiler = () => 'bravo'
+  })
+  var {VFile} = await import('vfile5')
+  var file = new VFile('alpha')
+
+  pipeline.processSync(file)
+
+  t.equal(
+    file.value,
+    'bravo',
+    'should set `file.value` when a vfile@5 is passed'
+  )
+  t.equal(
+    file.contents,
+    'bravo',
+    'should also set `file.contents` when a vfile@5 is passed'
+  )
+})


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

vfile@5 changed from the `contents` to the `value field.
Given that not all of the ecosystem has updated yet, and that some
version mismatches will occur for the foreseeable future, setting
both `contents` *and* `value` in those cases will hopefully alleviate
some of the struggles with updating.

Related to remarkjs/remark-frontmatter#16.

<!--do not edit: pr-->
