### PR TITLE
types: add support for buffer, other return values

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -354,9 +354,9 @@ export interface Compiler {
   /**
    * Transform an AST node/tree into text
    *
-   * @returns Compiled text
+   * @returns Compiled text (for `file.value`) or something else (for `file.result`)
    */
-  compile(): string
+  compile(): unknown
 }
 
 /**
@@ -370,9 +370,9 @@ export type CompilerConstructor = new (node: Node, file: VFile) => Compiler
  *
  * @param node Node/tree to be stringified
  * @param file File associated with node
- * @returns Compiled text
+ * @returns Compiled text (for `file.value`) or something else (for `file.result`)
  */
-export type CompilerFunction = (node: Node, file: VFile) => string
+export type CompilerFunction = (node: Node, file: VFile) => unknown
 
 /**
  * Access results from transforms


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Buffers, `null`/`undefined`, and `unknown` were not allowed from compilers.
While `string` is most often used as a return value, the other values should be allowed too

<!--do not edit: pr-->
