### PR TITLE
Fix `next` in types of transformer signature

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -221,10 +221,7 @@ export interface FrozenProcessor<P = Settings> {
  * @typeParam P Processor settings
  * @returns Optional Transformer.
  */
-export type Plugin<
-  S extends any[] = [Settings?],
-  P = Settings
-> = Attacher<S, P>
+export type Plugin<S extends any[] = [Settings?], P = Settings> = Attacher<S, P>
 
 /**
  * Configuration passed to a Plugin or Processor
@@ -259,10 +256,10 @@ export interface ProcessorSettings<P = Settings> {
  * @typeParam S Plugin settings
  * @typeParam P Processor settings
  */
-export type PluginTuple<
-  S extends any[] = [Settings?],
-  P = Settings
-> = [Plugin<S, P>, ...S]
+export type PluginTuple<S extends any[] = [Settings?], P = Settings> = [
+  Plugin<S, P>,
+  ...S
+]
 
 /**
  * A union of the different ways to add plugins to unified
@@ -316,11 +313,7 @@ export type Attacher<S extends any[] = [Settings?], P = Settings> = (
 export type Transformer = (
   node: Node,
   file: VFile,
-  next: (
-    error: Error | null,
-    tree?: Node,
-    file?: VFile
-  ) => Record<string, unknown>
+  next: (error?: Error | null, tree?: Node, file?: VFile) => void
 ) => Error | Node | Promise<Node> | void | Promise<void>
 
 /**

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -173,6 +173,9 @@ processor.use(
   // $ExpectError
   () => (tree: Node, file: VFile, next: () => {}) => {}
 )
+processor.use(() => (tree: Node, file: VFile, next: () => void) => {
+  next()
+})
 
 processor.use(pluginWithTwoSettings)
 processor.use(pluginWithTwoSettings).use(pluginWithTwoSettings)

--- a/types/unified-tests.ts
+++ b/types/unified-tests.ts
@@ -155,7 +155,7 @@ processor.use(
     (
       tree: Node,
       file: VFile,
-      next: (error: Error | null, tree: Node, file: VFile) => {}
+      next: (error: Error | null, tree: Node, file: VFile) => void
     ) => {}
 )
 processor.use(
@@ -163,11 +163,11 @@ processor.use(
     (
       tree: Node,
       file: VFile,
-      next: (error: Error | null, tree: Node) => {}
+      next: (error: Error | null, tree: Node) => void
     ) => {}
 )
 processor.use(
-  () => (tree: Node, file: VFile, next: (error: Error | null) => {}) => {}
+  () => (tree: Node, file: VFile, next: (error: Error | null) => void) => {}
 )
 processor.use(
   // $ExpectError


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

* `next` can also be called w/o parameters, to just continue on
* `next` returns `void` (`return next()` is fine in a transformer)

<!--do not edit: pr-->
