### PR TITLE
Add plugin tree type parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,11 +25,7 @@ type VFileWithOutput<Result> = Result extends Uint8Array // Buffer.
   : VFile
 
 // Get the right most non-void thing.
-type Specific<Fallback, Left = void, Right = void> = Right extends void
-  ? Left extends void
-    ? Fallback
-    : Left
-  : Right
+type Specific<Left = void, Right = void> = Right extends void ? Left : Right
 
 // Create a processor based on the input/output of a plugin.
 type UsePlugin<
@@ -45,8 +41,8 @@ type UsePlugin<
       // defines a parser, so set `ParseTree`.
       Processor<
         Output,
-        Specific<Node, Output, CurrentTree>,
-        Specific<void, Output, CompileTree>,
+        Specific<Output, CurrentTree>,
+        Specific<Output, CompileTree>,
         CompileResult
       >
     : Input extends Node
@@ -65,8 +61,8 @@ type UsePlugin<
   ? // If `Input` is `Node` and `Output` is not a `Node`, then this plugin
     // defines a compiler, so set `CompileTree` and `CompileResult`
     Processor<
-      Specific<void, Input, ParseTree>,
-      Specific<Node, Input, CurrentTree>,
+      Specific<Input, ParseTree>,
+      Specific<Input, CurrentTree>,
       Input,
       Output
     >

--- a/index.d.ts
+++ b/index.d.ts
@@ -321,7 +321,7 @@ export interface FrozenProcessor<
   ): Promise<Specific<Node, CompileTree>>
 
   /**
-   * Run transforms on the given node, synchroneously.
+   * Run transforms on the given node, synchronously.
    * Throws when asynchronous transforms are configured.
    *
    * @param node
@@ -826,7 +826,7 @@ export type CompilerFunction<Tree extends Node = Node, Result = unknown> = (
  * @typeParam Tree
  *   The tree that the callback receives.
  * @param error
- *   Error passed when unsuccesful.
+ *   Error passed when unsuccessful.
  * @param node
  *   Tree to transform.
  * @param file

--- a/index.d.ts
+++ b/index.d.ts
@@ -389,7 +389,7 @@ export interface FrozenProcessor<
   process(file: VFileCompatible): Promise<VFileWithOutput<CompileResult>>
 
   /**
-   * Process a file, synchroneously.
+   * Process a file, synchronously.
    * Throws when asynchronous transforms are configured.
    *
    * This performs all phases of the processor:
@@ -846,7 +846,7 @@ export type RunCallback<Tree extends Node = Node> = (
  * @typeParam File
  *   The file that the callback receives.
  * @param error
- *   Error passed when unsuccesful.
+ *   Error passed when unsuccessful.
  * @param file
  *   File passed when successful.
  * @returns

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
 import {expectType, expectError} from 'tsd'
 import {Node, Parent, Literal} from 'unist'
 import {VFile} from 'vfile'
@@ -155,8 +157,10 @@ unified()
   .use(() => () => {
     /* Empty */
   })
-  .use(() => () => {
-    throw new Error('x')
+  .use(() => (x) => {
+    if (x) {
+      throw new Error('x')
+    }
   })
 
 // Plugins bound to a certain node.
@@ -266,3 +270,193 @@ unified().use({
   ],
   settings: {}
 })
+
+// Input and output types.
+interface ReactNode {
+  kind: string
+}
+
+const someMdast: MdastRoot = {
+  type: 'root',
+  children: [{type: 'paragraph', children: [{type: 'text', value: 'a'}]}]
+}
+
+const someHast: HastRoot = {
+  type: 'root',
+  children: [
+    {
+      type: 'element',
+      tagName: 'a',
+      properties: {},
+      children: [{type: 'text', value: 'a'}]
+    }
+  ]
+}
+
+const remarkParse: Plugin<void[], string, MdastRoot> = () => {
+  /* Empty */
+}
+
+const remarkStringify: Plugin<void[], MdastRoot, string> = () => {
+  /* Empty */
+}
+
+const rehypeParse: Plugin<void[], string, HastRoot> = () => {
+  /* Empty */
+}
+
+const rehypeStringify: Plugin<void[], HastRoot, string> = () => {
+  /* Empty */
+}
+
+const rehypeStringifyBuffer: Plugin<void[], HastRoot, Buffer> = () => {
+  /* Empty */
+}
+
+const explicitRemarkPlugin: Plugin<void[], MdastRoot> = () => {
+  /* Empty */
+}
+
+const implicitPlugin: Plugin<void[]> = () => {
+  /* Empty */
+}
+
+const remarkRehype: Plugin<void[], MdastRoot, HastRoot> = () => {
+  /* Empty */
+}
+
+const explicitRehypePlugin: Plugin<void[], HastRoot> = () => {
+  /* Empty */
+}
+
+const rehypeReact: Plugin<void[], HastRoot, ReactNode> = () => {
+  /* Empty */
+}
+
+// If a plugin is defined with string as input and a node as output, it
+// configures a parser.
+expectType<MdastRoot>(unified().use(remarkParse).parse(''))
+expectType<HastRoot>(unified().use(rehypeParse).parse(''))
+expectType<Node>(unified().parse(''))
+
+// If a plugin is defined with a node as input and a non-node as output, it
+// configures a compiler.
+expectType<string>(unified().use(remarkStringify).stringify(someMdast))
+expectType<string>(unified().use(rehypeStringify).stringify(someHast))
+expectType<Buffer>(unified().use(rehypeStringifyBuffer).stringify(someHast))
+expectType<string>(unified().stringify(someHast))
+expectType<ReactNode>(unified().use(rehypeReact).stringify(someHast))
+expectError(unified().use(remarkStringify).stringify(someHast))
+expectError(unified().use(rehypeStringify).stringify(someMdast))
+
+// Compilers configure the output of `process`, too.
+expectType<VFile>(unified().use(remarkStringify).processSync(''))
+expectType<VFile>(unified().use(rehypeStringify).processSync(''))
+expectType<VFile>(unified().use(rehypeStringifyBuffer).processSync(''))
+expectType<VFile>(unified().processSync(''))
+expectType<VFile & {result: ReactNode}>(
+  unified().use(rehypeReact).processSync('')
+)
+
+// A parser plugin defines the input of `.run`:
+expectType<MdastRoot>(unified().use(remarkParse).runSync(someMdast))
+expectError(unified().use(remarkParse).runSync(someHast))
+
+// A compiler plugin defines the output of `.run`:
+expectType<HastRoot>(unified().use(rehypeStringify).runSync(someMdast))
+expectType<HastRoot>(
+  unified().use(remarkParse).use(rehypeStringify).runSync(someMdast)
+)
+
+unified()
+  .use(rehypeStringify)
+  .run(someMdast)
+  .then((thing) => {
+    expectType<HastRoot>(thing)
+  })
+
+unified()
+  .use(rehypeStringify)
+  .run(someMdast, (error, thing) => {
+    expectType<Error | null | undefined>(error)
+    expectType<HastRoot | undefined>(thing)
+  })
+
+// A compiler plugin defines the output of `.process`:
+expectType<VFile & {result: ReactNode}>(
+  unified().use(rehypeReact).processSync('')
+)
+expectType<VFile & {result: ReactNode}>(
+  unified().use(remarkParse).use(rehypeReact).processSync('')
+)
+
+unified()
+  .use(rehypeReact)
+  .process('')
+  .then((file) => {
+    expectType<VFile & {result: ReactNode}>(file)
+  })
+
+unified()
+  .use(rehypeReact)
+  .process('', (error, thing) => {
+    expectType<Error | null | undefined>(error)
+    expectType<(VFile & {result: ReactNode}) | undefined>(thing)
+  })
+
+// Plugins work!
+unified()
+  .use(remarkParse)
+  .use(explicitRemarkPlugin)
+  .use(implicitPlugin)
+  .use(remarkRehype)
+  .use(implicitPlugin)
+  .use(rehypeStringify)
+  .freeze()
+
+// Parsers define the input of transformers.
+unified().use(() => (node) => {
+  expectType<Node>(node)
+})
+unified()
+  .use(remarkParse)
+  .use(() => (node) => {
+    expectType<MdastRoot>(node)
+  })
+unified()
+  .use(rehypeParse)
+  .use(() => (node) => {
+    expectType<HastRoot>(node)
+  })
+
+unified()
+  // Using a parser plugin also defines the current tree (see next).
+  .use(remarkParse)
+  // A plugin following a typed parser receives the defined AST.
+  // If it doesn’t resolve anything, that AST remains for the next plugin.
+  .use(() => (node) => {
+    expectType<MdastRoot>(node)
+  })
+  // A plugin that returns a certain AST, defines it for the next plugin.
+  .use(() => (node) => {
+    expectType<MdastRoot>(node)
+    return someHast
+  })
+  .use(() => (node) => {
+    expectType<HastRoot>(node)
+  })
+  .use(rehypeStringify)
+
+// Using two parsers or compilers is fine. The last one sticks.
+const p1 = unified().use(remarkParse).use(rehypeParse)
+expectType<HastRoot>(p1.parse(''))
+const p2 = unified().use(remarkStringify).use(rehypeStringify)
+expectError(p2.stringify(someMdast))
+
+// Using mismatched explicit plugins is fine (for now).
+unified()
+  .use(explicitRemarkPlugin)
+  .use(explicitRehypePlugin)
+  .use(explicitRemarkPlugin)
+
+/* eslint-enable @typescript-eslint/no-floating-promises */

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectError} from 'tsd'
-import {Node} from 'unist'
+import {Node, Parent, Literal} from 'unist'
 import {VFile} from 'vfile'
 import {
   unified,
@@ -158,3 +158,55 @@ unified()
   .use(() => () => {
     throw new Error('x')
   })
+
+// Plugins bound to a certain node.
+
+// A small subset of mdast.
+interface Root extends Parent {
+  type: 'root'
+  children: Flow[]
+}
+
+type Flow = Paragraph
+
+interface Paragraph extends Parent {
+  type: 'paragraph'
+  children: Phrasing[]
+}
+
+type Phrasing = Text
+
+interface Text extends Literal {
+  type: 'text'
+  value: string
+}
+
+const explicitPluginWithTree: Plugin<void[], Root> = () => (tree, file) => {
+  expectType<Root>(tree)
+  expectType<VFile>(file)
+}
+
+unified().use(explicitPluginWithTree)
+
+unified().use([explicitPluginWithTree])
+
+unified().use({plugins: [explicitPluginWithTree], settings: {}})
+
+unified().use(() => (tree: Root) => {
+  expectType<Root>(tree)
+})
+
+unified().use([
+  () => (tree: Root) => {
+    expectType<Root>(tree)
+  }
+])
+
+unified().use({
+  plugins: [
+    () => (tree: Root) => {
+      expectType<Root>(tree)
+    }
+  ],
+  settings: {}
+})

--- a/test/async-function.js
+++ b/test/async-function.js
@@ -1,28 +1,31 @@
+/**
+ * @typedef {import('unist').Node} Node
+ */
+
 import test from 'tape'
 import {VFile} from 'vfile'
 import {unified} from '../index.js'
 
 test('async function transformer () {}', (t) => {
   const givenFile = new VFile('alpha')
+  /** @type {Node} */
   const givenNode = {type: 'bravo'}
+  /** @type {Node} */
   const modifiedNode = {type: 'charlie'}
 
   t.plan(5)
 
   unified()
     .use(() => async function () {})
+    .use(() => async (tree, file) => {
+      t.equal(tree, givenNode, 'passes correct tree to an async function')
+      t.equal(file, givenFile, 'passes correct file to an async function')
+      return modifiedNode
+    })
     .use(
       () =>
         async function () {
           return undefined
-        }
-    )
-    .use(
-      () =>
-        async function (tree, file) {
-          t.equal(tree, givenNode, 'passes correct tree to an async function')
-          t.equal(file, givenFile, 'passes correct file to an async function')
-          return modifiedNode
         }
     )
     .run(givenNode, givenFile, (error, tree, file) => {

--- a/test/async-function.js
+++ b/test/async-function.js
@@ -8,26 +8,26 @@ import {unified} from '../index.js'
 
 test('async function transformer () {}', (t) => {
   const givenFile = new VFile('alpha')
-  /** @type {Node} */
   const givenNode = {type: 'bravo'}
-  /** @type {Node} */
   const modifiedNode = {type: 'charlie'}
 
   t.plan(5)
 
   unified()
     .use(() => async function () {})
-    .use(() => async (tree, file) => {
-      t.equal(tree, givenNode, 'passes correct tree to an async function')
-      t.equal(file, givenFile, 'passes correct file to an async function')
-      return modifiedNode
-    })
     .use(
+      // Note: TS JS doesn’t understand the `Promise<undefined>` w/o explicit type.
+      /** @type {import('../index.js').Plugin<[]>} */
       () =>
         async function () {
           return undefined
         }
     )
+    .use(() => async (tree, file) => {
+      t.equal(tree, givenNode, 'passes correct tree to an async function')
+      t.equal(file, givenFile, 'passes correct file to an async function')
+      return modifiedNode
+    })
     .run(givenNode, givenFile, (error, tree, file) => {
       t.error(error, 'should’t fail')
       t.equal(tree, modifiedNode, 'passes given tree to `done`')

--- a/test/run.js
+++ b/test/run.js
@@ -118,6 +118,8 @@ test('run(node[, file], done)', (t) => {
 
   unified()
     .use(
+      // Note: TS JS doesn’t understand the promise w/o explicit type.
+      /** @type {import('../index.js').Plugin<[]>} */
       () =>
         function () {
           return new Promise((resolve) => {
@@ -371,6 +373,8 @@ test('run(node[, file])', (t) => {
 
   unified()
     .use(
+      // Note: TS JS doesn’t understand the promise w/o explicit type.
+      /** @type {import('../index.js').Plugin<[]>} */
       () =>
         function () {
           return new Promise((resolve) => {
@@ -579,6 +583,8 @@ test('runSync(node[, file])', (t) => {
     () => {
       unified()
         .use(
+          // Note: TS JS doesn’t understand the promise w/o explicit type.
+          /** @type {import('../index.js').Plugin<[]>} */
           () =>
             function () {
               return new Promise((resolve) => {

--- a/test/use.js
+++ b/test/use.js
@@ -262,19 +262,19 @@ test('use(plugin[, options])', (t) => {
   t.test('should attach transformers', (t) => {
     const processor = unified()
     const givenNode = {type: 'test'}
+    const condition = true
 
     t.plan(3)
 
     processor
-      .use(
-        () =>
-          function (node, file) {
-            t.equal(node, givenNode, 'should attach a transformer (#1)')
-            t.ok('message' in file, 'should attach a transformer (#2)')
+      .use(() => (node, file) => {
+        t.equal(node, givenNode, 'should attach a transformer (#1)')
+        t.ok('message' in file, 'should attach a transformer (#2)')
 
-            throw new Error('Alpha bravo charlie')
-          }
-      )
+        if (condition) {
+          throw new Error('Alpha bravo charlie')
+        }
+      })
       .freeze()
 
     t.throws(


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This allows plugins to define what type of tree they receive and yield in their transformer.
It does not prevent misuse of those plugins (such as a rehype plugin and then a remark plugin). Nor does it handle parser or compiler plugins.

<!--do not edit: pr-->
