### PR TITLE
Fix type of `run` signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -316,7 +316,7 @@ export interface FrozenProcessor<
    *   Promise that resolves to the resulting tree.
    */
   run(
-    node: Specific<Node, CompileTree>,
+    node: Specific<Node, ParseTree>,
     file?: VFileCompatible | undefined
   ): Promise<Specific<Node, CompileTree>>
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -360,13 +360,19 @@ expectType<VFile & {result: ReactNode}>(
 )
 
 // A parser plugin defines the input of `.run`:
+expectType<Promise<MdastRoot>>(unified().use(remarkParse).run(someMdast))
 expectType<MdastRoot>(unified().use(remarkParse).runSync(someMdast))
+expectError(unified().use(remarkParse).run(someHast))
 expectError(unified().use(remarkParse).runSync(someHast))
 
 // A compiler plugin defines the input/output of `.run`:
+expectError(unified().use(rehypeStringify).run(someMdast))
 expectError(unified().use(rehypeStringify).runSync(someMdast))
 // As a parser and a compiler are set, it can be assumed that the input of `run`
 // is the result of the parser, and the output is the input of the compiler.
+expectType<Promise<HastRoot>>(
+  unified().use(remarkParse).use(rehypeStringify).run(someMdast)
+)
 expectType<HastRoot>(
   unified().use(remarkParse).use(rehypeStringify).runSync(someMdast)
 )


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The 3rd overload signature (the promise variant) of `FrozenProcessor.run` now correctly accepts a tree of type `ParseTree` instead of `CompileTree`.

Fix #173.

<!--do not edit: pr-->
