### PR TITLE
Add useful error on empty presets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -197,6 +197,12 @@ function base() {
      * @returns {void}
      */
     function addPreset(result) {
+      if (!('plugins' in result) && !('settings' in result)) {
+        throw new Error(
+          'Expected usable value but received an empty preset, which is probably a mistake: presets typically come with `plugins` and sometimes with `settings`, but this has neither'
+        )
+      }
+
       addList(result.plugins)
 
       if (result.settings) {

--- a/test/use.js
+++ b/test/use.js
@@ -308,11 +308,13 @@ test('use(preset)', (t) => {
     'should throw on invalid `plugins` (2)'
   )
 
-  t.test('should support empty presets', (t) => {
-    const processor = unified().use({}).freeze()
-    t.equal(processor.attachers.length, 0)
-    t.end()
-  })
+  t.throws(
+    () => {
+      unified().use({}).freeze()
+    },
+    /Expected usable value but received an empty preset/,
+    'should throw on empty presets'
+  )
 
   t.test('should support presets with empty plugins', (t) => {
     const processor = unified().use({plugins: []}).freeze()


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Empty presets are most likely a mistake by the user. At best, they do nothing.
This improves the situation for humans that make mistakes, by throwing a useful error.

Closes GH-200.

<!--do not edit: pr-->
