### PR TITLE
Update `typescript`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "remark-preset-wooorm": "^9.0.0",
     "tsd": "^0.24.0",
     "type-coverage": "^2.0.0",
-    "typescript": "^4.0.0",
+    "typescript": "^5.0.0",
     "xo": "^0.53.0"
   },
   "scripts": {

--- a/test/process.js
+++ b/test/process.js
@@ -47,6 +47,10 @@ test('process(file, done)', () => {
     })
     .use(
       () =>
+        /**
+         * @param {Node} tree
+         * @param {VFile} file
+         */
         function (tree, file) {
           assert.equal(tree, givenNode, 'should pass `tree` to transformers')
           assert.equal(file, givenFile, 'should pass `file` to transformers')
@@ -100,6 +104,10 @@ test('process(file)', () => {
     })
     .use(
       () =>
+        /**
+         * @param {Node} tree
+         * @param {VFile} file
+         */
         function (tree, file) {
           assert.equal(tree, givenNode, 'should pass `tree` to transformers')
           assert.equal(file, givenFile, 'should pass `file` to transformers')

--- a/test/run.js
+++ b/test/run.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('unist').Node} Node
+ */
+
 import process from 'node:process'
 import assert from 'node:assert/strict'
 import test from 'node:test'
@@ -549,6 +553,10 @@ test('runSync(node[, file])', async () => {
   unified()
     .use(
       () =>
+        /**
+         * @param {Node} tree
+         * @param {VFile} file
+         */
         function (tree, file) {
           assert.equal(tree, givenNode, 'passes given tree to transformers')
           assert.equal(file, givenFile, 'passes given file to transformers')
@@ -559,6 +567,10 @@ test('runSync(node[, file])', async () => {
   unified()
     .use(
       () =>
+        /**
+         * @param {Node} _
+         * @param {VFile} file
+         */
         function (_, file) {
           assert.equal(
             file.toString(),

--- a/test/use.js
+++ b/test/use.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import('unist').Node} Node
+ * @typedef {import('vfile').VFile} VFile
+ */
+
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {unified} from '../index.js'
@@ -252,14 +257,21 @@ test('use(plugin[, options])', async (t) => {
     const condition = true
 
     processor
-      .use(() => (node, file) => {
-        assert.equal(node, givenNode, 'should attach a transformer (#1)')
-        assert.ok('message' in file, 'should attach a transformer (#2)')
+      .use(
+        () =>
+          /**
+           * @param {Node} node
+           * @param {VFile} file
+           */
+          function (node, file) {
+            assert.equal(node, givenNode, 'should attach a transformer (#1)')
+            assert.ok('message' in file, 'should attach a transformer (#2)')
 
-        if (condition) {
-          throw new Error('Alpha bravo charlie')
-        }
-      })
+            if (condition) {
+              throw new Error('Alpha bravo charlie')
+            }
+          }
+      )
       .freeze()
 
     assert.throws(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "lib": ["es2020"],
     "module": "node16",
     "newLine": "lf",
-    "skipLibCheck": true,
     "strict": true,
     "target": "es2020"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "exactOptionalPropertyTypes": true,
-    "forceConsistentCasingInFileNames": true,
     "lib": ["es2020"],
     "module": "node16",
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2020"],
     "module": "node16",
-    "newLine": "lf",
     "strict": true,
     "target": "es2020"
   }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

First step towards moving most or all of the types into JSDoc.
Previously lack of overloads was a blocker.
TypeScript 5 includes overload syntax for JSDoc https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#overload-support-in-jsdoc

The full migration to JSDoc will be large, this is the first step towards that, ensuring the project still builds on TypeScript 5, and building it with TS5 by default.

<!--do not edit: pr-->
