### PR TITLE
Import from unified instead of relative index.js

### DIFF
--- a/test/async-function.js
+++ b/test/async-function.js
@@ -5,7 +5,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {VFile} from 'vfile'
-import {unified} from '../index.js'
+import {unified} from 'unified'
 
 test('async function transformer () {}', () => {
   const givenFile = new VFile('alpha')

--- a/test/core.js
+++ b/test/core.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import {unified} from '../index.js'
+import {unified} from 'unified'
 
 test('unified()', () => {
   /** @type {number} */

--- a/test/data.js
+++ b/test/data.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import {unified} from '../index.js'
+import {unified} from 'unified'
 
 test('data(key[, value])', () => {
   const processor = unified()

--- a/test/freeze.js
+++ b/test/freeze.js
@@ -1,10 +1,10 @@
 /**
- * @typedef {import('../index.js').Plugin} Plugin
+ * @typedef {import('unified').Plugin} Plugin
  */
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import {unified} from '../index.js'
+import {unified} from 'unified'
 import {SimpleCompiler, SimpleParser} from './util/simple.js'
 
 test('freeze()', async (t) => {

--- a/test/parse.js
+++ b/test/parse.js
@@ -5,7 +5,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import {unified} from '../index.js'
+import {unified} from 'unified'
 
 test('parse(file)', () => {
   const processor = unified()

--- a/test/process.js
+++ b/test/process.js
@@ -1,15 +1,15 @@
 /**
  * @typedef {import('unist').Literal<string>} Literal
  * @typedef {import('unist').Node} Node
- * @typedef {import('../index.js').Parser} Parser
- * @typedef {import('../index.js').Compiler} Compiler
+ * @typedef {import('unified').Parser} Parser
+ * @typedef {import('unified').Compiler} Compiler
  */
 
 import {Buffer} from 'node:buffer'
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {VFile} from 'vfile'
-import {unified} from '../index.js'
+import {unified} from 'unified'
 import {SimpleCompiler, SimpleParser} from './util/simple.js'
 
 test('process(file, done)', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -2,7 +2,7 @@ import process from 'node:process'
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {VFile} from 'vfile'
-import {unified} from '../index.js'
+import {unified} from 'unified'
 
 test('run(node[, file], done)', async () => {
   const givenFile = new VFile('alpha')

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -5,7 +5,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {VFile} from 'vfile'
-import {unified} from '../index.js'
+import {unified} from 'unified'
 
 test('stringify(node[, file])', () => {
   const processor = unified()

--- a/test/use.js
+++ b/test/use.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import {unified} from '../index.js'
+import {unified} from 'unified'
 
 test('use(plugin[, options])', async (t) => {
   await t.test('should ignore missing values', () => {

--- a/test/util/simple.js
+++ b/test/util/simple.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {import('unist').Literal<string>} Literal
- * @typedef {import('../../index.js').Parser} Parser
- * @typedef {import('../../index.js').Compiler} Compiler
+ * @typedef {import('unified').Parser} Parser
+ * @typedef {import('unified').Compiler} Compiler
  */
 
 /** @type {Parser} */


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

In test code, imports now import from `unified` instead of a relative path to `index.js`. This way package exports are also tested, both runtime and for type checking. This truly tests the public interface.

I’m not saying we should go over all packages to apply this immediately, but when working on a package, I think it’s a good idea to apply this pattern. This PR is mostly to share and discuss the idea.

<!--do not edit: pr-->
