### PR TITLE
Test passing a literal object to processor.stringify

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -575,7 +575,7 @@ const remarkStringify: Plugin<[], MdastRoot, string> = function () {
   // Empty.
 }
 
-expectType<Uint8Array | string>(
+expectType<string>(
   unified().use(remarkStringify).stringify({type: 'root', children: []})
 )
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -575,6 +575,10 @@ const remarkStringify: Plugin<[], MdastRoot, string> = function () {
   // Empty.
 }
 
+expectType<Uint8Array | string>(
+  unified().use(remarkStringify).stringify({type: 'root', children: []})
+)
+
 expectType<HastRoot>(unified().use(remarkParse).use(rehypeParse).parse(''))
 
 expectType<string>(


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The object type is correctly inferred as an mdast Root. We should make sure this doesn’t break.

<!--do not edit: pr-->
