### PR TITLE
Add TypeScript declaration maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .DS_Store
 *.d.ts
 *.log
+*.map
 yarn.lock
 !/index.d.ts
 !/test/types.d.ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "checkJs": true,
     "customConditions": ["development"],
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "exactOptionalPropertyTypes": true,
     "lib": ["es2022"],


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This enables “Go to Definition” in TypeScript based editors. Without a declaration map, this takes the user to the type definition. With a declaration map, this takes the user to the location in the source code.

The downside is, this means the source code needs to be published to npm as well. For projects using types in JSDoc this is not a problem, as the source code is already published as-is.

I’m creating a PR here to propose it, but I actually thing this is useful for all of unified. It might be too much work going over all packages just to enable it, but I think it’s useful to enable when a project is already being touched.

<!--do not edit: pr-->
