### PR TITLE
Fix building with TypeScript 5.5

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1049,7 +1049,12 @@ export class Processor extends CallableInstance {
    *
    * @overload
    * @param {Plugin<Parameters, Input, Output>} plugin
-   * @param {...(Parameters | [boolean])} parameters
+   * @param {boolean} parameters
+   * @returns {UsePlugin<ParseTree, HeadTree, TailTree, CompileTree, CompileResult, Input, Output>}
+   *
+   * @overload
+   * @param {Plugin<Parameters, Input, Output>} plugin
+   * @param {...Parameters} parameters
    * @returns {UsePlugin<ParseTree, HeadTree, TailTree, CompileTree, CompileResult, Input, Output>}
    *
    * @param {PluggableList | Plugin | Preset | null | undefined} value


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

We ran into a regression when building unified with TypeScript 5.5. Splitting the overload into 2 separate overloads fixes it.

This doesn’t require a new release. It just fixes the types if they are built now, the types published to npm are fine.

<!--do not edit: pr-->
