### PR TITLE
Accept non mutable array of plugins in the use function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ export type {
   Preset,
   ProcessCallback,
   Processor,
+  ReadonlyPluggableList,
   RunCallback,
   // `Settings` is typed and exposed below.
   TransformCallback,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -548,6 +548,15 @@ expectType<Processor>(
   })
 )
 
+const PLUGINS = [
+  remarkParse,
+  remarkLint,
+  remarkLintImplicit,
+  remarkRehype,
+  rehypeStringify
+] as const
+expectType<Processor>(unified().use(PLUGINS))
+
 /**
  * Register our setting.
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,11 @@
  *   List of plugins and presets.
  */
 
+/**
+ * @typedef {ReadonlyArray<Pluggable>} ReadonlyPluggableList
+ *   Readonly list of plugins and presets.
+ */
+
 // Note: we can’t use `callback` yet as it messes up `this`:
 //  <https://github.com/microsoft/TypeScript/issues/55197>.
 /**
@@ -168,7 +173,7 @@
  *   Sharable configuration.
  *
  *   They can contain plugins and settings.
- * @property {PluggableList | undefined} [plugins]
+ * @property {ReadonlyPluggableList | undefined} [plugins]
  *   List of plugins and presets (optional).
  * @property {Settings | undefined} [settings]
  *   Shared settings for parsers and compilers (optional).
@@ -1038,7 +1043,7 @@ export class Processor extends CallableInstance {
    * @returns {Processor<ParseTree, HeadTree, TailTree, CompileTree, CompileResult>}
    *
    * @overload
-   * @param {PluggableList} list
+   * @param {ReadonlyPluggableList} list
    * @returns {Processor<ParseTree, HeadTree, TailTree, CompileTree, CompileResult>}
    *
    * @overload
@@ -1046,7 +1051,7 @@ export class Processor extends CallableInstance {
    * @param {...(Parameters | [boolean])} parameters
    * @returns {UsePlugin<ParseTree, HeadTree, TailTree, CompileTree, CompileResult, Input, Output>}
    *
-   * @param {PluggableList | Plugin | Preset | null | undefined} value
+   * @param {ReadonlyPluggableList | Plugin | Preset | null | undefined} value
    *   Usable value.
    * @param {...unknown} parameters
    *   Parameters, when a plugin is given as a usable value.
@@ -1064,7 +1069,7 @@ export class Processor extends CallableInstance {
     } else if (typeof value === 'function') {
       addPlugin(value, parameters)
     } else if (typeof value === 'object') {
-      if (Array.isArray(value)) {
+      if (isReadonlyArray(value)) {
         addList(value)
       } else {
         addPreset(value)
@@ -1083,7 +1088,7 @@ export class Processor extends CallableInstance {
       if (typeof value === 'function') {
         addPlugin(value, [])
       } else if (typeof value === 'object') {
-        if (Array.isArray(value)) {
+        if (isReadonlyArray(value)) {
           const [plugin, ...parameters] =
             /** @type {PluginTuple<Array<unknown>>} */ (value)
           addPlugin(plugin, parameters)
@@ -1114,7 +1119,7 @@ export class Processor extends CallableInstance {
     }
 
     /**
-     * @param {PluggableList | null | undefined} plugins
+     * @param {ReadonlyPluggableList | null | undefined} plugins
      * @returns {undefined}
      */
     function addList(plugins) {
@@ -1122,7 +1127,7 @@ export class Processor extends CallableInstance {
 
       if (plugins === null || plugins === undefined) {
         // Empty.
-      } else if (Array.isArray(plugins)) {
+      } else if (isReadonlyArray(plugins)) {
         while (++index < plugins.length) {
           const thing = plugins[index]
           add(thing)
@@ -1268,6 +1273,18 @@ function assertDone(name, asyncName, complete) {
       '`' + name + '` finished async. Use `' + asyncName + '` instead'
     )
   }
+}
+
+/**
+ * Check if a value is an array (including readonly arrays).
+ *
+ * @param {unknown} value
+ *   Value to check.
+ * @returns {value is Array<unknown> | ReadonlyArray<unknown>}
+ *   Whether `value` is an array.
+ */
+function isReadonlyArray(value) {
+  return Array.isArray(value)
 }
 
 /**


### PR DESCRIPTION
This change is compatible with previous code, it makes it more obvious that the library does not modify the array of plugins and only iterates over the array.

Fixes #266

<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [X] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
* [X] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
* [X] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
* [X] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aunifiedjs&type=issues and https://github.com/orgs/unifiedjs/discussions -->
* [x] I made sure the docs are up to date (I don't think they need a change)
* [X] I included tests (or that’s not needed)

### Description of changes

Change the type of the first parameter of `use` to accept not only arrays but also readonly arrays (immutable). As the library does not modify it, we can accept this wider type.

<!--do not edit: pr-->
