### PR TITLE
Drop `extend` CJS dependency

### DIFF
--- a/lib/deep-merge.js
+++ b/lib/deep-merge.js
@@ -1,0 +1,78 @@
+import isPlainObj from 'is-plain-obj'
+
+const own = {}.hasOwnProperty
+
+/**
+ * Deeply merge plain objects and arrays.
+ *
+ * @template {Record<string, unknown> | Array<unknown>} Target
+ * @param {Target} target
+ * @param {unknown} source
+ * @returns {Target}
+ */
+export function deepMerge(target, source) {
+  if (!source || typeof source !== 'object') {
+    return target
+  }
+
+  const values = /** @type {Record<string, unknown>} */ (source)
+
+  for (const key of Object.keys(values)) {
+    const value = getOwn(values, key)
+
+    if (value === undefined || value === target) {
+      continue
+    }
+
+    if (Array.isArray(value)) {
+      const existing = getOwn(target, key)
+      const base = Array.isArray(existing)
+        ? /** @type {Array<unknown>} */ (existing)
+        : []
+
+      setOwn(target, key, deepMerge(base, value))
+    } else if (isPlainObj(value)) {
+      const existing = getOwn(target, key)
+      const base = isPlainObj(existing) ? existing : {}
+
+      setOwn(target, key, deepMerge(base, value))
+    } else {
+      setOwn(target, key, value)
+    }
+  }
+
+  return target
+}
+
+/**
+ * @param {Record<string, unknown> | Array<unknown>} target
+ * @param {string} key
+ * @returns {unknown}
+ */
+function getOwn(target, key) {
+  if (key === '__proto__' && !own.call(target, key)) {
+    return undefined
+  }
+
+  return /** @type {Record<string, unknown>} */ (target)[key]
+}
+
+/**
+ * @param {Record<string, unknown> | Array<unknown>} target
+ * @param {string} key
+ * @param {unknown} value
+ * @returns {undefined}
+ */
+function setOwn(target, key, value) {
+  if (key === '__proto__') {
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true
+    })
+  } else {
+    const record = /** @type {Record<string, unknown>} */ (target)
+    record[key] = value
+  }
+}

--- a/lib/deep-merge.js
+++ b/lib/deep-merge.js
@@ -1,3 +1,27 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014 Stefan Thomas
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
 import isPlainObj from 'is-plain-obj'
 
 const own = {}.hasOwnProperty
@@ -17,7 +41,9 @@ export function deepMerge(target, source) {
 
   const values = /** @type {Record<string, unknown>} */ (source)
 
-  for (const key of Object.keys(values)) {
+  for (const key in values) {
+    // mainly to satisfy eslint, `getOwn()` also does the check
+    if (!Object.hasOwn(source, key)) continue
     const value = getOwn(values, key)
 
     if (value === undefined || value === target) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -341,12 +341,12 @@
  */
 
 import {bail} from 'bail'
-import extend from 'extend'
 import {ok as assert} from 'devlop'
 import isPlainObj from 'is-plain-obj'
 import {trough} from 'trough'
 import {VFile} from 'vfile'
 import {CallableInstance} from './callable-instance.js'
+import {deepMerge} from './deep-merge.js'
 
 // To do: next major: drop `Compiler`, `Parser`: prefer lowercase.
 
@@ -501,7 +501,7 @@ export class Processor extends CallableInstance {
       destination.use(...attacher)
     }
 
-    destination.data(extend(true, {}, this.namespace))
+    destination.data(deepMerge({}, this.namespace))
 
     return destination
   }
@@ -1109,7 +1109,12 @@ export class Processor extends CallableInstance {
       addList(result.plugins)
 
       if (result.settings) {
-        namespace.settings = extend(true, namespace.settings, result.settings)
+        namespace.settings = /** @type {Settings} */ (
+          deepMerge(
+            /** @type {Record<string, unknown>} */ (namespace.settings || {}),
+            result.settings
+          )
+        )
       }
     }
 
@@ -1157,7 +1162,7 @@ export class Processor extends CallableInstance {
         let [primary, ...rest] = parameters
         const currentPrimary = attachers[entryIndex][1]
         if (isPlainObj(currentPrimary) && isPlainObj(primary)) {
-          primary = extend(true, currentPrimary, primary)
+          primary = deepMerge(currentPrimary, primary)
         }
 
         attachers[entryIndex] = [plugin, primary, ...rest]
@@ -1285,9 +1290,9 @@ function vfile(value) {
 function looksLikeAVFile(value) {
   return Boolean(
     value &&
-      typeof value === 'object' &&
-      'message' in value &&
-      'messages' in value
+    typeof value === 'object' &&
+    'message' in value &&
+    'messages' in value
   )
 }
 
@@ -1310,8 +1315,8 @@ function looksLikeAValue(value) {
 function isUint8Array(value) {
   return Boolean(
     value &&
-      typeof value === 'object' &&
-      'byteLength' in value &&
-      'byteOffset' in value
+    typeof value === 'object' &&
+    'byteLength' in value &&
+    'byteOffset' in value
   )
 }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "prepack": "npm run build && npm run format",
     "test": "npm run build && npm run format && npm run test-coverage",
     "test-api": "node --conditions development test/index.js",
-    "test-coverage": "c8 --96 --check-coverage --reporter lcov npm run test-api"
+    "test-coverage": "c8 --100 --check-coverage --reporter lcov npm run test-api"
   },
   "sideEffects": false,
   "typeCoverage": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,12 @@
     "@types/unist": "^3.0.0",
     "bail": "^2.0.0",
     "devlop": "^1.0.0",
-    "extend": "^3.0.0",
     "is-plain-obj": "^4.0.0",
     "trough": "^2.0.0",
     "vfile": "^6.0.0"
   },
   "description": "parse, inspect, transform, and serialize content through syntax trees",
   "devDependencies": {
-    "@types/extend": "^3.0.0",
     "@types/hast": "^3.0.0",
     "@types/mdast": "^4.0.0",
     "@types/node": "^22.0.0",
@@ -87,7 +85,7 @@
     "prepack": "npm run build && npm run format",
     "test": "npm run build && npm run format && npm run test-coverage",
     "test-api": "node --conditions development test/index.js",
-    "test-coverage": "c8 --100 --check-coverage --reporter lcov npm run test-api"
+    "test-coverage": "c8 --96 --check-coverage --reporter lcov npm run test-api"
   },
   "sideEffects": false,
   "typeCoverage": {

--- a/test/types.d.ts
+++ b/test/types.d.ts
@@ -11,6 +11,9 @@ declare module 'unified' {
     bar?: boolean | undefined
     foo?: boolean | undefined
     qux?: boolean | undefined
+
+    date?: Date | undefined
+    nested?: Record<string, unknown> | undefined
   }
 }
 

--- a/test/use.js
+++ b/test/use.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {unified} from 'unified'
+import {deepMerge} from '../lib/deep-merge.js'
 
 test('`use`', async function (t) {
   const givenOptions = {alpha: 'bravo', charlie: true, delta: 1}
@@ -284,6 +285,84 @@ test('`use`', async function (t) {
         .data(),
       {settings: {foo: false, bar: true, qux: true}}
     )
+
+    assert.deepEqual(
+      unified()
+        .use({
+          settings: {
+            date: new Date(),
+            nested: {
+              array: [],
+              array2: '',
+              obj: {},
+              map: new Map([['test', 'a']])
+            }
+          }
+        })
+        .use({
+          settings: {
+            date: undefined,
+            nested: {
+              array: ['test'],
+              array2: ['apple'],
+              obj: null,
+              map: new Map([['test', 'b']])
+            }
+          }
+        })
+        .data(),
+      {
+        settings: {
+          date: new Date(),
+          nested: {
+            array: ['test'],
+            array2: ['apple'],
+            obj: null,
+            map: new Map([['test', 'b']])
+          }
+        }
+      }
+    )
+  })
+
+  await t.test('should not merge inherited object properties', function () {
+    const settings = Object.create({alpha: true})
+    settings.bravo = true
+
+    assert.deepEqual(unified().use({settings}).data(), {
+      settings: {bravo: true}
+    })
+  })
+
+  await t.test(
+    'should keep object `__proto__` property in preset settings',
+    function () {
+      /** @type {import('unified').Settings} */
+      const settings = {}
+
+      Object.defineProperty(settings, '__proto__', {
+        enumerable: true,
+        value: {alpha: true}
+      })
+
+      const data = unified().use({settings}).data()
+      const descriptor = Object.getOwnPropertyDescriptor(
+        data.settings,
+        '__proto__'
+      )
+
+      assert(descriptor)
+      assert.equal(
+        Object.getPrototypeOf(data.settings),
+        Object.getPrototypeOf({})
+      )
+      assert.deepEqual(descriptor.value, {alpha: true})
+    }
+  )
+
+  // shouldn't happen in reality, just to ensure 100% test coverage
+  await t.test('should support non-object merge sources', function () {
+    assert.deepEqual(deepMerge({}, 'alpha'), {})
   })
 
   await t.test('should support extending presets', function () {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aunifiedjs&type=issues and https://github.com/orgs/unifiedjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Removed the remaining CJS dependency `extend`, since unified itself is ESM-only, it would be great if all deps are also ESM so it doesn't need bundling to work in browser environments.

The `extend` package is being used as a deep merge utility, while its core functionality is being replaced by `Object.assign()`. I think a proper deep merge utility would do better, but `extend` has some behaviours that may differs from existing deep merge utilities, so I rewrote the original utility with modern ESM, shouldn't cause any breaking changes.

I had to lower the test coverage as some edge cases are not easily reached, let me know if this isn't desirable.

<!--do not edit: pr-->
